### PR TITLE
Go Heavier: location logos, detail stats, and a simpler dashboard

### DIFF
--- a/src/components/go_heavier/Location.css
+++ b/src/components/go_heavier/Location.css
@@ -22,6 +22,22 @@
     min-height: 220px;
 }
 
+.location-logo {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 64px;
+    width: 100%;
+}
+
+.location-logo img {
+    max-height: 100%;
+    max-width: 160px;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+}
+
 .location-main-content {
     width: 100%;
 }

--- a/src/components/go_heavier/Location.tsx
+++ b/src/components/go_heavier/Location.tsx
@@ -17,7 +17,7 @@ interface State {
         address_city: string
         address_country_iso3: string
         address_postal_code: string
-        logo: string
+        logo_url: string
     }
     loading: boolean
     error: string | null
@@ -32,7 +32,7 @@ interface Props {
     address_city: string
     address_country_iso3: string
     address_postal_code: string
-    logo?: string
+    logo_url?: string
     created_at: string
     updated_at: string
     onDeleted?: (locationName: string) => void
@@ -54,7 +54,7 @@ export class Location extends React.Component<Props, State> {
                 address_city: props.address_city,
                 address_country_iso3: props.address_country_iso3,
                 address_postal_code: props.address_postal_code,
-                logo: props.logo ?? ""
+                logo_url: props.logo_url ?? ""
             },
             loading: false,
             error: null
@@ -98,7 +98,7 @@ export class Location extends React.Component<Props, State> {
                 address_city: this.props.address_city,
                 address_country_iso3: this.props.address_country_iso3,
                 address_postal_code: this.props.address_postal_code,
-                logo: this.props.logo ?? ""
+                logo_url: this.props.logo_url ?? ""
             },
             error: null
         })
@@ -112,7 +112,7 @@ export class Location extends React.Component<Props, State> {
     }
 
     validateForm = (): boolean => {
-        const { name, address_line1, address_city, address_country_iso3, address_postal_code, logo } = this.state.formData
+        const { name, address_line1, address_city, address_country_iso3, address_postal_code, logo_url } = this.state.formData
 
         if (!name.trim()) {
             this.setState({ error: "Name is required" })
@@ -144,11 +144,11 @@ export class Location extends React.Component<Props, State> {
             return false
         }
 
-        if (logo.trim()) {
+        if (logo_url.trim()) {
             try {
-                new URL(logo.trim())
+                new URL(logo_url.trim())
             } catch {
-                this.setState({ error: "Logo must be a valid URL" })
+                this.setState({ error: "Logo URL must be a valid URL" })
                 return false
             }
         }
@@ -280,10 +280,10 @@ export class Location extends React.Component<Props, State> {
                                 Logo URL:
                                 <input
                                     type="url"
-                                    name="logo"
-                                    value={this.state.formData.logo}
+                                    name="logo_url"
+                                    value={this.state.formData.logo_url}
                                     onChange={this.handleChange}
-                                    placeholder="https://example.com/logo.png"
+                                    placeholder="https://..."
                                 />
                             </label>
                             {this.state.error && <p className="error-message">{this.state.error}</p>}
@@ -303,6 +303,11 @@ export class Location extends React.Component<Props, State> {
 
         return (
             <div className="location-container" onClick={this.handleCardClick}>
+                {this.props.logo_url && (
+                    <div className="location-logo">
+                        <img src={this.props.logo_url} alt={`${this.props.name} logo`} />
+                    </div>
+                )}
                 <div className="location-main-content">
                     <h2 className="location-title">{this.props.name}</h2>
                     <p className="location-description">

--- a/src/components/go_heavier/Location.tsx
+++ b/src/components/go_heavier/Location.tsx
@@ -17,6 +17,7 @@ interface State {
         address_city: string
         address_country_iso3: string
         address_postal_code: string
+        logo: string
     }
     loading: boolean
     error: string | null
@@ -31,6 +32,7 @@ interface Props {
     address_city: string
     address_country_iso3: string
     address_postal_code: string
+    logo?: string
     created_at: string
     updated_at: string
     onDeleted?: (locationName: string) => void
@@ -51,7 +53,8 @@ export class Location extends React.Component<Props, State> {
                 address_line2: props.address_line2,
                 address_city: props.address_city,
                 address_country_iso3: props.address_country_iso3,
-                address_postal_code: props.address_postal_code
+                address_postal_code: props.address_postal_code,
+                logo: props.logo ?? ""
             },
             loading: false,
             error: null
@@ -94,7 +97,8 @@ export class Location extends React.Component<Props, State> {
                 address_line2: this.props.address_line2,
                 address_city: this.props.address_city,
                 address_country_iso3: this.props.address_country_iso3,
-                address_postal_code: this.props.address_postal_code
+                address_postal_code: this.props.address_postal_code,
+                logo: this.props.logo ?? ""
             },
             error: null
         })
@@ -108,7 +112,7 @@ export class Location extends React.Component<Props, State> {
     }
 
     validateForm = (): boolean => {
-        const { name, address_line1, address_city, address_country_iso3, address_postal_code } = this.state.formData
+        const { name, address_line1, address_city, address_country_iso3, address_postal_code, logo } = this.state.formData
 
         if (!name.trim()) {
             this.setState({ error: "Name is required" })
@@ -138,6 +142,15 @@ export class Location extends React.Component<Props, State> {
         if (!address_postal_code.trim()) {
             this.setState({ error: "Postal code is required" })
             return false
+        }
+
+        if (logo.trim()) {
+            try {
+                new URL(logo.trim())
+            } catch {
+                this.setState({ error: "Logo must be a valid URL" })
+                return false
+            }
         }
 
         return true
@@ -261,6 +274,16 @@ export class Location extends React.Component<Props, State> {
                                     value={this.state.formData.address_postal_code}
                                     onChange={this.handleChange}
                                     required
+                                />
+                            </label>
+                            <label>
+                                Logo URL:
+                                <input
+                                    type="url"
+                                    name="logo"
+                                    value={this.state.formData.logo}
+                                    onChange={this.handleChange}
+                                    placeholder="https://example.com/logo.png"
                                 />
                             </label>
                             {this.state.error && <p className="error-message">{this.state.error}</p>}

--- a/src/components/go_heavier/Stats.css
+++ b/src/components/go_heavier/Stats.css
@@ -1,0 +1,233 @@
+/* Shared stats presentation for the location and exercise detail pages */
+
+.stats-section {
+    grid-column: 1 / -1;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.stat-tile {
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    padding: 20px 16px;
+    text-align: center;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.stat-tile-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1.2;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 6px;
+}
+
+.stat-tile-label {
+    font-size: 0.75rem;
+    color: #718096;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.stats-detail {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 24px;
+}
+
+@media (min-width: 768px) {
+    .stats-detail {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+/* Ranked breakdown list */
+.top-list-title {
+    margin: 0 0 16px 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.top-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.top-list-item + .top-list-item {
+    margin-top: 16px;
+}
+
+.top-list-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 6px;
+}
+
+.top-list-name {
+    color: #2c3e50;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.top-list-name:hover {
+    color: #667eea;
+    text-decoration: underline;
+}
+
+.top-list-metric {
+    color: #5a6c7d;
+    font-size: 0.875rem;
+    flex-shrink: 0;
+}
+
+.top-list-bar-track {
+    height: 8px;
+    border-radius: 4px;
+    background: #f0f0f0;
+    overflow: hidden;
+}
+
+.top-list-bar {
+    height: 100%;
+    border-radius: 4px;
+    background: #667eea;
+    min-width: 2px;
+    transition: width 0.3s ease;
+}
+
+.top-list-meta {
+    margin-top: 6px;
+    font-size: 0.8125rem;
+    color: #718096;
+}
+
+/* Latest session summary */
+.latest-workout-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px 16px;
+    margin-bottom: 16px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.latest-workout-date {
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.latest-workout-location {
+    color: #5a6c7d;
+    text-decoration: none;
+}
+
+.latest-workout-location:hover {
+    color: #667eea;
+    text-decoration: underline;
+}
+
+.latest-workout-count {
+    margin-left: auto;
+    font-size: 0.875rem;
+    color: #718096;
+}
+
+/* Set breakdown table */
+.set-table-wrapper {
+    overflow-x: auto;
+}
+
+.set-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9375rem;
+}
+
+.set-table th {
+    text-align: left;
+    padding: 8px 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #718096;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 1px solid #e0e0e0;
+    white-space: nowrap;
+}
+
+.set-table td {
+    padding: 10px 12px;
+    color: #5a6c7d;
+    border-bottom: 1px solid #f0f0f0;
+    white-space: nowrap;
+}
+
+.set-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.set-table tbody tr:hover td {
+    background: #f8f9fa;
+}
+
+.set-table .set-notes {
+    white-space: normal;
+    color: #718096;
+    font-size: 0.875rem;
+}
+
+/* Best set */
+.best-set-headline {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.best-set-weight {
+    font-size: 2.25rem;
+    font-weight: 700;
+    line-height: 1.2;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.best-set-reps {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #5a6c7d;
+}
+
+.best-set-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    margin-top: 12px;
+    font-size: 0.9375rem;
+    color: #718096;
+}
+
+.best-set-notes {
+    margin: 12px 0 0 0;
+    padding-top: 12px;
+    border-top: 1px solid #f0f0f0;
+    color: #718096;
+    font-size: 0.875rem;
+}

--- a/src/components/go_heavier/Workout.tsx
+++ b/src/components/go_heavier/Workout.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { useNavigate } from "react-router-dom"
+import { formatNotes } from "../../configs"
 import "./Workout.css"
 
 interface WorkoutProps {
@@ -37,6 +38,7 @@ class WorkoutClass extends React.Component<WorkoutProps & { navigate: any }> {
     }
 
     render(): React.ReactNode {
+        const notes = formatNotes(this.props.notes)
         const totalWeight = this.props.weight_kg + 
                           (this.props.bar_weight_kg || 0) + 
                           (this.props.supplementary_weight_kg || 0)
@@ -71,9 +73,9 @@ class WorkoutClass extends React.Component<WorkoutProps & { navigate: any }> {
                     </div>
                 </div>
 
-                {this.props.notes && (
+                {notes && (
                     <div className="workout-notes">
-                        💬 {this.props.notes}
+                        💬 {notes}
                     </div>
                 )}
             </div>

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -7,3 +7,12 @@ export function countryCodeToEmoji(countryCode: string): string {
         .map((char) => 127397 + char.charCodeAt(0))
     return String.fromCodePoint(...codePoints)
 }
+
+// Missing free-text values come back from the API as placeholder strings
+// ("NaN", "None", "null") rather than as an empty value or JSON null.
+const TEXT_PLACEHOLDERS = new Set(["nan", "none", "null", "undefined"])
+
+export function formatNotes(notes?: string | null): string {
+    const trimmed = (notes ?? "").trim()
+    return TEXT_PLACEHOLDERS.has(trimmed.toLowerCase()) ? "" : trimmed
+}

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,5 +1,8 @@
 export const API_URL = process.env.API_URL || "http://localhost:8000"
 
+// Every workout page the app has fetched, written by the workouts page.
+export const WORKOUTS_CACHE_KEY = "go-heavier-workouts"
+
 export function countryCodeToEmoji(countryCode: string): string {
     const codePoints = countryCode
         .toUpperCase()

--- a/src/pages/GoHeavier.css
+++ b/src/pages/GoHeavier.css
@@ -37,22 +37,32 @@
     font-weight: 300;
 }
 
+.dashboard-tagline {
+    max-width: 620px;
+    margin: 0 auto !important;
+    line-height: 1.6;
+}
+
 /* Stats Overview */
 .stats-overview {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 32px;
     margin-bottom: 48px;
 }
 
 .stat-card {
     background: white;
-    border-radius: 16px;
-    padding: 28px;
+    border-radius: 20px;
+    padding: 40px 32px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 20px;
+    text-align: center;
+    gap: 16px;
+    min-height: 240px;
+    justify-content: center;
     transition: all 0.3s ease;
     border: 1px solid rgba(0, 0, 0, 0.06);
 }
@@ -70,16 +80,17 @@ a.stat-card {
 }
 
 .stat-icon {
-    font-size: 2.5rem;
+    font-size: 3.5rem;
     opacity: 0.9;
+    line-height: 1;
 }
 
 .stat-content {
-    flex: 1;
+    width: 100%;
 }
 
 .stat-value {
-    font-size: 2.25rem;
+    font-size: 3rem;
     font-weight: 700;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     -webkit-background-clip: text;
@@ -90,108 +101,18 @@ a.stat-card {
 }
 
 .stat-label {
-    font-size: 0.875rem;
-    color: #718096;
+    font-size: 1rem;
+    color: #2c3e50;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
 
-/* Config Grid */
-.config-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-    gap: 32px;
-    margin-bottom: 48px;
-}
-
-/* Config Cards */
-.config-card {
-    background: white;
-    border-radius: 16px;
-    padding: 32px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
-    transition: all 0.3s ease;
-    border: 1px solid rgba(0, 0, 0, 0.06);
-}
-
-.config-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-}
-
-.config-card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 16px;
-}
-
-.config-card-header h2 {
-    margin: 0;
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: #2d3748;
-}
-
-.count-badge {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    padding: 6px 14px;
-    border-radius: 20px;
-    font-size: 0.875rem;
-    font-weight: 600;
-}
-
-.config-description {
+.stat-caption {
+    margin: 8px 0 0 0;
+    font-size: 0.9375rem;
     color: #718096;
-    margin: 0 0 20px 0;
-    font-size: 0.95rem;
-    line-height: 1.6;
-}
-
-/* Tag Container */
-.tag-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 16px;
-}
-
-.tag {
-    display: inline-block;
-    padding: 8px 16px;
-    border-radius: 8px;
-    font-size: 0.875rem;
-    font-weight: 500;
-    text-transform: capitalize;
-    transition: all 0.2s ease;
-}
-
-.tag-country {
-    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-    color: white;
-}
-
-.tag-muscle {
-    background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
-    color: white;
-}
-
-.tag-specific {
-    background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
-    color: white;
-}
-
-.tag-more {
-    background: #e2e8f0;
-    color: #4a5568;
-    font-style: italic;
-}
-
-.tag:hover {
-    transform: scale(1.05);
-    opacity: 0.9;
+    line-height: 1.5;
 }
 
 /* Dashboard Footer */
@@ -229,28 +150,16 @@ a.stat-card {
     }
 
     .stat-card {
-        padding: 20px;
+        padding: 32px 24px;
+        min-height: 0;
     }
 
     .stat-icon {
-        font-size: 2rem;
+        font-size: 2.75rem;
     }
 
     .stat-value {
-        font-size: 1.75rem;
-    }
-
-    .config-grid {
-        grid-template-columns: 1fr;
-        gap: 24px;
-    }
-
-    .config-card {
-        padding: 24px;
-    }
-
-    .config-card-header h2 {
-        font-size: 1.25rem;
+        font-size: 2.25rem;
     }
 }
 

--- a/src/pages/GoHeavier.css
+++ b/src/pages/GoHeavier.css
@@ -57,6 +57,13 @@
     border: 1px solid rgba(0, 0, 0, 0.06);
 }
 
+/* Stat cards link through to their section */
+a.stat-card {
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+}
+
 .stat-card:hover {
     transform: translateY(-4px);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);

--- a/src/pages/GoHeavier.css
+++ b/src/pages/GoHeavier.css
@@ -288,3 +288,41 @@
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
 }
+
+.error-container {
+    opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.error-container.retrying {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.error-container button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    min-width: 150px;
+}
+
+.error-container button:disabled {
+    cursor: default;
+    transform: none;
+    box-shadow: none;
+}
+
+.button-spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.4);
+    border-top: 2px solid white;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/src/pages/GoHeavier.tsx
+++ b/src/pages/GoHeavier.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Link } from "react-router-dom"
 
 import { API_URL } from "../configs"
 import GoHeavierNavBar from "../components/go_heavier/NavBar"
@@ -131,27 +132,27 @@ export default class GoHeavier extends React.Component<{}, State> {
                             </div>
 
                             <div className="stats-overview">
-                                <div className="stat-card">
+                                <Link to="/go-heavier/locations" className="stat-card">
                                     <div className="stat-icon">📍</div>
                                     <div className="stat-content">
                                         <div className="stat-value">{this.state.locationCount ?? '...'}</div>
                                         <div className="stat-label">Locations</div>
                                     </div>
-                                </div>
-                                <div className="stat-card">
+                                </Link>
+                                <Link to="/go-heavier/exercises" className="stat-card">
                                     <div className="stat-icon">🏋️</div>
                                     <div className="stat-content">
                                         <div className="stat-value">{this.state.exerciseCount ?? '...'}</div>
                                         <div className="stat-label">Exercises</div>
                                     </div>
-                                </div>
-                                <div className="stat-card">
+                                </Link>
+                                <Link to="/go-heavier/workouts" className="stat-card">
                                     <div className="stat-icon">📊</div>
                                     <div className="stat-content">
                                         <div className="stat-value">{this.state.workoutCount ?? '...'}</div>
                                         <div className="stat-label">Workouts</div>
                                     </div>
-                                </div>
+                                </Link>
                             </div>
 
                             <div className="config-grid">

--- a/src/pages/GoHeavier.tsx
+++ b/src/pages/GoHeavier.tsx
@@ -36,7 +36,12 @@ export default class GoHeavier extends React.Component<{}, State> {
         }
     }
 
-    fetchConfig = async () => {
+    fetchConfig = async (minDuration: number = 300) => {
+        const startedAt = Date.now()
+        const waitOut = () => new Promise<void>(resolve =>
+            setTimeout(resolve, Math.max(0, minDuration - (Date.now() - startedAt)))
+        )
+
         this.setState({ isRefreshing: true })
         try {
             // Get workout count from cache
@@ -53,18 +58,18 @@ export default class GoHeavier extends React.Component<{}, State> {
             const locations = await locationsRes.json()
             const exercises = await exercisesRes.json()
             
-            setTimeout(() => {
-                this.setState({ 
-                    config, 
-                    configLoaded: true, 
-                    isRefreshing: false,
-                    locationCount: locations.length,
-                    exerciseCount: exercises.length,
-                    workoutCount: workoutCount
-                })
-            }, 300)
+            await waitOut()
+            this.setState({ 
+                config, 
+                configLoaded: true, 
+                isRefreshing: false,
+                locationCount: locations.length,
+                exerciseCount: exercises.length,
+                workoutCount: workoutCount
+            })
         } catch (error) {
             console.error("Error fetching config:", error)
+            await waitOut()
             this.setState({ configLoaded: false, isRefreshing: false })
         }
     }
@@ -75,6 +80,11 @@ export default class GoHeavier extends React.Component<{}, State> {
 
     handleRefresh = () => {
         this.fetchConfig()
+    }
+
+    handleRetry = () => {
+        // Keep the loading state on screen long enough to be visible
+        this.fetchConfig(1000)
     }
 
     render(): React.ReactNode {
@@ -99,10 +109,17 @@ export default class GoHeavier extends React.Component<{}, State> {
                     )}
 
                     {this.state.configLoaded === false && (
-                        <div className="error-container">
+                        <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Configuration</h2>
                             <p className="error-message">Unable to fetch config from server</p>
-                            <button onClick={this.fetchConfig}>Retry</button>
+                            <button onClick={this.handleRetry} disabled={this.state.isRefreshing}>
+                                {this.state.isRefreshing ? (
+                                    <>
+                                        <span className="button-spinner"></span>
+                                        Retrying...
+                                    </>
+                                ) : 'Retry'}
+                            </button>
                         </div>
                     )}
 

--- a/src/pages/GoHeavier.tsx
+++ b/src/pages/GoHeavier.tsx
@@ -1,23 +1,12 @@
 import React from "react"
 import { Link } from "react-router-dom"
 
-import { API_URL } from "../configs"
+import { API_URL, WORKOUTS_CACHE_KEY } from "../configs"
 import GoHeavierNavBar from "../components/go_heavier/NavBar"
 import "./GoHeavier.css"
 
-interface ConfigData {
-    default: {
-        IsoCountryCode: string[]
-    }
-    "go-heavier": {
-        MuscleGroup: string[]
-        SpecificMuscle: string[]
-    }
-}
-
 interface State {
-    configLoaded: boolean | null
-    config: ConfigData | null
+    loaded: boolean | null
     isRefreshing: boolean
     locationCount?: number
     exerciseCount?: number
@@ -28,8 +17,7 @@ export default class GoHeavier extends React.Component<{}, State> {
     constructor(props: {}) {
         super(props)
         this.state = {
-            configLoaded: null,
-            config: null,
+            loaded: null,
             isRefreshing: false,
             locationCount: undefined,
             exerciseCount: undefined,
@@ -37,7 +25,7 @@ export default class GoHeavier extends React.Component<{}, State> {
         }
     }
 
-    fetchConfig = async (minDuration: number = 300) => {
+    fetchCounts = async (minDuration: number = 300) => {
         const startedAt = Date.now()
         const waitOut = () => new Promise<void>(resolve =>
             setTimeout(resolve, Math.max(0, minDuration - (Date.now() - startedAt)))
@@ -45,47 +33,44 @@ export default class GoHeavier extends React.Component<{}, State> {
 
         this.setState({ isRefreshing: true })
         try {
-            // Get workout count from cache
-            const cachedWorkouts = localStorage.getItem('go-heavier-workouts')
-            const workoutCount = cachedWorkouts ? JSON.parse(cachedWorkouts).length : 0
-            
-            const [configRes, locationsRes, exercisesRes] = await Promise.all([
-                fetch(`${API_URL}/config`),
+            // Workouts are paged, so the count comes from what the workouts page cached.
+            const cachedWorkouts = localStorage.getItem(WORKOUTS_CACHE_KEY)
+            const workoutCount = cachedWorkouts ? JSON.parse(cachedWorkouts).length : undefined
+
+            const [locationsRes, exercisesRes] = await Promise.all([
                 fetch(`${API_URL}/go-heavier/locations`),
                 fetch(`${API_URL}/go-heavier/exercises`)
             ])
-            
-            const config = await configRes.json()
+
             const locations = await locationsRes.json()
             const exercises = await exercisesRes.json()
-            
+
             await waitOut()
-            this.setState({ 
-                config, 
-                configLoaded: true, 
+            this.setState({
+                loaded: true,
                 isRefreshing: false,
                 locationCount: locations.length,
                 exerciseCount: exercises.length,
                 workoutCount: workoutCount
             })
         } catch (error) {
-            console.error("Error fetching config:", error)
+            console.error("Error fetching dashboard counts:", error)
             await waitOut()
-            this.setState({ configLoaded: false, isRefreshing: false })
+            this.setState({ loaded: false, isRefreshing: false })
         }
     }
 
     componentDidMount() {
-        this.fetchConfig()
+        this.fetchCounts()
     }
 
     handleRefresh = () => {
-        this.fetchConfig()
+        this.fetchCounts()
     }
 
     handleRetry = () => {
         // Keep the loading state on screen long enough to be visible
-        this.fetchConfig(1000)
+        this.fetchCounts(1000)
     }
 
     render(): React.ReactNode {
@@ -93,9 +78,9 @@ export default class GoHeavier extends React.Component<{}, State> {
             <div className="center-container-grid">
                 <GoHeavierNavBar />
                 <div className="page-container">
-                    {this.state.configLoaded && !this.state.isRefreshing && (
-                        <button 
-                            onClick={this.handleRefresh} 
+                    {this.state.loaded && !this.state.isRefreshing && (
+                        <button
+                            onClick={this.handleRefresh}
                             className={`refresh-arrow-button ${this.state.isRefreshing ? 'spinning' : ''}`}
                             title="Refresh"
                         >
@@ -103,16 +88,16 @@ export default class GoHeavier extends React.Component<{}, State> {
                         </button>
                     )}
 
-                    {this.state.configLoaded === null && (
+                    {this.state.loaded === null && (
                         <div className="loading-spinner">
                             <div className="spinner"></div>
                         </div>
                     )}
 
-                    {this.state.configLoaded === false && (
+                    {this.state.loaded === false && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
-                            <h2>Failed to Load Configuration</h2>
-                            <p className="error-message">Unable to fetch config from server</p>
+                            <h2>Failed to Load Dashboard</h2>
+                            <p className="error-message">Unable to fetch data from server</p>
                             <button onClick={this.handleRetry} disabled={this.state.isRefreshing}>
                                 {this.state.isRefreshing ? (
                                     <>
@@ -124,11 +109,15 @@ export default class GoHeavier extends React.Component<{}, State> {
                         </div>
                     )}
 
-                    {this.state.configLoaded && this.state.config && (
+                    {this.state.loaded && (
                         <div className={`go-heavier-dashboard ${this.state.isRefreshing ? 'refreshing' : ''}`}>
                             <div className="dashboard-hero">
-                                <h1>💪 Go Heavier Dashboard</h1>
-                                <p>System Configuration & Metadata</p>
+                                <h1>💪 Go Heavier</h1>
+                                <p className="dashboard-tagline">
+                                    A training log for the gym. Keep track of where you train, the
+                                    exercises you do, and every set you lift — then watch the numbers
+                                    climb.
+                                </p>
                             </div>
 
                             <div className="stats-overview">
@@ -137,6 +126,7 @@ export default class GoHeavier extends React.Component<{}, State> {
                                     <div className="stat-content">
                                         <div className="stat-value">{this.state.locationCount ?? '...'}</div>
                                         <div className="stat-label">Locations</div>
+                                        <p className="stat-caption">The gyms you train at</p>
                                     </div>
                                 </Link>
                                 <Link to="/go-heavier/exercises" className="stat-card">
@@ -144,6 +134,7 @@ export default class GoHeavier extends React.Component<{}, State> {
                                     <div className="stat-content">
                                         <div className="stat-value">{this.state.exerciseCount ?? '...'}</div>
                                         <div className="stat-label">Exercises</div>
+                                        <p className="stat-caption">Movements in your library</p>
                                     </div>
                                 </Link>
                                 <Link to="/go-heavier/workouts" className="stat-card">
@@ -151,64 +142,13 @@ export default class GoHeavier extends React.Component<{}, State> {
                                     <div className="stat-content">
                                         <div className="stat-value">{this.state.workoutCount ?? '...'}</div>
                                         <div className="stat-label">Workouts</div>
+                                        <p className="stat-caption">Sets you have logged</p>
                                     </div>
                                 </Link>
                             </div>
 
-                            <div className="config-grid">
-                                <div className="config-card">
-                                    <div className="config-card-header">
-                                        <h2>🌍 Countries</h2>
-                                        <span className="count-badge">{this.state.config.default.IsoCountryCode.length}</span>
-                                    </div>
-                                    <p className="config-description">
-                                        ISO 3166-1 alpha-3 country codes supported by the system
-                                    </p>
-                                    <div className="tag-container">
-                                        {this.state.config.default.IsoCountryCode.slice(0, 20).map((country, index) => (
-                                            <span key={index} className="tag tag-country">{country}</span>
-                                        ))}
-                                        {this.state.config.default.IsoCountryCode.length > 20 && (
-                                            <span className="tag tag-more">
-                                                +{this.state.config.default.IsoCountryCode.length - 20} more
-                                            </span>
-                                        )}
-                                    </div>
-                                </div>
-
-                                <div className="config-card">
-                                    <div className="config-card-header">
-                                        <h2>💪 Muscle Groups</h2>
-                                        <span className="count-badge">{this.state.config["go-heavier"].MuscleGroup.length}</span>
-                                    </div>
-                                    <p className="config-description">
-                                        Primary muscle groups available for exercise categorization
-                                    </p>
-                                    <div className="tag-container">
-                                        {this.state.config["go-heavier"].MuscleGroup.map((group, index) => (
-                                            <span key={index} className="tag tag-muscle">{group}</span>
-                                        ))}
-                                    </div>
-                                </div>
-
-                                <div className="config-card">
-                                    <div className="config-card-header">
-                                        <h2>🎯 Specific Muscles</h2>
-                                        <span className="count-badge">{this.state.config["go-heavier"].SpecificMuscle.length}</span>
-                                    </div>
-                                    <p className="config-description">
-                                        Detailed muscle targets for precise exercise classification
-                                    </p>
-                                    <div className="tag-container">
-                                        {this.state.config["go-heavier"].SpecificMuscle.map((muscle, index) => (
-                                            <span key={index} className="tag tag-specific">{muscle}</span>
-                                        ))}
-                                    </div>
-                                </div>
-                            </div>
-
                             <div className="dashboard-footer">
-                                <p>Configuration loaded from API • Last refreshed: {new Date().toLocaleString()}</p>
+                                <p>Last refreshed: {new Date().toLocaleString()}</p>
                             </div>
                         </div>
                     )}

--- a/src/pages/go_heavier/ExerciseDetail.css
+++ b/src/pages/go_heavier/ExerciseDetail.css
@@ -65,6 +65,11 @@
     flex: 1;
 }
 
+/* Stats sit full width below the image and details row */
+.exercise-detail-container .stats-section {
+    margin-top: 32px;
+}
+
 /* Responsive adjustments */
 @media (max-width: 767px) {
     .exercise-detail-header h1 {

--- a/src/pages/go_heavier/ExerciseDetail.tsx
+++ b/src/pages/go_heavier/ExerciseDetail.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
-import { API_URL } from "../../configs"
+import { API_URL, formatNotes } from "../../configs"
+import "../../components/go_heavier/Stats.css"
 import "./ExerciseDetail.css"
 import "../go_heavier/Exercises.css"
 import "../../components/go_heavier/ExerciseForm.css"
@@ -19,8 +20,56 @@ interface ExerciseData {
     updated_at: string
 }
 
+// Guard on the page walk so a misbehaving endpoint can't loop forever.
+const MAX_WORKOUT_PAGES = 500
+
+interface WorkoutSet {
+    id: string
+    location_id: string
+    exercise_id: string
+    workout_time: string
+    index: number
+    repetitions: number
+    weight_kg: number
+    bar_weight_kg: number
+    supplementary_weight_kg: number
+    notes: string
+}
+
+interface TopLocation {
+    location_id: string
+    name: string
+    sessions: number
+    sets: number
+    repetitions: number
+    volume_kg: number
+}
+
+interface ExerciseStatsData {
+    exercise_id: string
+    name: string
+    sessions: number
+    first_performed: string | null
+    last_performed: string | null
+    total_sets: number
+    total_repetitions: number
+    total_volume_kg: number
+    heaviest_weight_kg: number | null
+    average_sets_per_session: number
+    average_repetitions_per_set: number
+    distinct_locations: number
+    top_locations?: TopLocation[]
+}
+
 interface State {
     exercise: ExerciseData | null
+    stats: ExerciseStatsData | null
+    statsLoading: boolean
+    statsError: string | null
+    exerciseSets: WorkoutSet[] | null
+    setsLoading: boolean
+    setsError: string | null
+    locationNames: Record<string, string>
     loading: boolean
     error: string | null
     isRefreshing: boolean
@@ -44,6 +93,13 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
         super(props)
         this.state = {
             exercise: null,
+            stats: null,
+            statsLoading: true,
+            statsError: null,
+            exerciseSets: null,
+            setsLoading: true,
+            setsError: null,
+            locationNames: {},
             loading: true,
             error: null,
             isRefreshing: false,
@@ -65,6 +121,79 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
 
     componentDidMount() {
         this.fetchExercise()
+        this.fetchStats()
+        this.fetchExerciseSets()
+        this.fetchLocationNames()
+    }
+
+    fetchLocationNames = async () => {
+        try {
+            const response = await fetch(`${API_URL}/go-heavier/locations`)
+            const locations = await response.json()
+            const locationNames: Record<string, string> = {}
+            locations.forEach((location: { id: string; name: string }) => {
+                locationNames[location.id] = location.name
+            })
+            this.setState({ locationNames })
+        } catch (error) {
+            console.error("Error fetching locations:", error)
+        }
+    }
+
+    // Every set of this exercise, needed for the latest session and the best set.
+    // The workouts endpoint's exercise_id filter currently returns a 500, so the
+    // pages are walked and matched here. Swap to ?exercise_id= once the API is fixed.
+    fetchExerciseSets = async () => {
+        this.setState({ setsLoading: true, setsError: null })
+        try {
+            const workouts: WorkoutSet[] = []
+            const batchSize = 4
+            let page = 1
+            let exhausted = false
+
+            while (!exhausted && page <= MAX_WORKOUT_PAGES) {
+                const firstPage = page
+                const pageNumbers = Array.from({ length: batchSize }, (_, offset) => firstPage + offset)
+                const responses = await Promise.all(
+                    pageNumbers.map(pageNumber => fetch(`${API_URL}/go-heavier/workouts?page=${pageNumber}`))
+                )
+
+                for (const response of responses) {
+                    if (!response.ok) {
+                        throw new Error("Failed to load workouts")
+                    }
+                    const pageWorkouts: WorkoutSet[] = await response.json()
+                    if (pageWorkouts.length === 0) {
+                        exhausted = true
+                    } else {
+                        workouts.push(...pageWorkouts)
+                    }
+                }
+                page += batchSize
+            }
+
+            const exerciseSets = workouts.filter(workout => workout.exercise_id === this.props.id)
+            this.setState({ exerciseSets, setsLoading: false })
+        } catch (error) {
+            console.error("Error fetching workouts for this exercise:", error)
+            this.setState({ setsError: (error as Error).message, setsLoading: false })
+        }
+    }
+
+
+    fetchStats = async () => {
+        this.setState({ statsLoading: true, statsError: null })
+        try {
+            const response = await fetch(`${API_URL}/go-heavier/exercises/${this.props.id}/stats`)
+            if (!response.ok) {
+                throw new Error("Failed to load stats")
+            }
+            const stats = await response.json()
+            this.setState({ stats, statsLoading: false })
+        } catch (error) {
+            console.error("Error fetching exercise stats:", error)
+            this.setState({ statsError: (error as Error).message, statsLoading: false })
+        }
     }
 
     fetchExercise = async () => {
@@ -96,6 +225,8 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
 
     handleRefresh = async () => {
         this.setState({ isRefreshing: true })
+        this.fetchStats()
+        this.fetchExerciseSets()
         try {
             const response = await fetch(`${API_URL}/go-heavier/exercises/${this.props.id}`)
             if (!response.ok) {
@@ -223,7 +354,105 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
         }
     }
 
+    formatCount = (value: number): string => value.toLocaleString()
+
+    formatWeight = (value: number | null): string =>
+        value === null || value === undefined ? "\u2014" : `${Math.round(value).toLocaleString()} kg`
+
+    formatPerformedDate = (value: string | null): string => {
+        if (!value) {
+            return "\u2014"
+        }
+        return new Date(value).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric"
+        })
+    }
+
+    // Every set from the most recent day this exercise was performed.
+    getLatestSets = (): WorkoutSet[] => {
+        const sets = this.state.exerciseSets ?? []
+        if (sets.length === 0) {
+            return []
+        }
+
+        const latest = new Date(Math.max(...sets.map(set => new Date(set.workout_time).getTime())))
+        const onLatestDay = (value: string) => {
+            const performed = new Date(value)
+            return performed.getFullYear() === latest.getFullYear()
+                && performed.getMonth() === latest.getMonth()
+                && performed.getDate() === latest.getDate()
+        }
+
+        return sets.filter(set => onLatestDay(set.workout_time)).sort((a, b) => a.index - b.index)
+    }
+
+    // Heaviest set, the same measure as the "Heaviest lift" stat. Ties go to the
+    // set with the most repetitions, then to the most recent one.
+    getBestSet = (): WorkoutSet | null => {
+        const sets = this.state.exerciseSets ?? []
+        if (sets.length === 0) {
+            return null
+        }
+
+        return sets.reduce((best, set) => {
+            if (set.weight_kg !== best.weight_kg) {
+                return set.weight_kg > best.weight_kg ? set : best
+            }
+            if (set.repetitions !== best.repetitions) {
+                return set.repetitions > best.repetitions ? set : best
+            }
+            return new Date(set.workout_time) > new Date(best.workout_time) ? set : best
+        })
+    }
+
+    formatSessionDate = (value: string): string =>
+        new Date(value).toLocaleDateString("en-US", {
+            weekday: "long",
+            year: "numeric",
+            month: "long",
+            day: "numeric"
+        })
+
+    // The bar length encodes sessions, the same measure the list is ordered by.
+    renderTopLocations = (topLocations: TopLocation[]): React.ReactNode => {
+        const mostSessions = Math.max(...topLocations.map(location => location.sessions), 1)
+
+        return topLocations.map((location) => (
+            <li key={location.location_id} className="top-list-item">
+                <div className="top-list-head">
+                    <a
+                        className="top-list-name"
+                        href={`/go-heavier/locations/${location.location_id}`}
+                        onClick={(e) => {
+                            e.preventDefault()
+                            this.props.navigate(`/go-heavier/locations/${location.location_id}`)
+                        }}
+                    >
+                        {location.name}
+                    </a>
+                    <span className="top-list-metric">
+                        {this.formatCount(location.sessions)} sessions
+                    </span>
+                </div>
+                <div className="top-list-bar-track">
+                    <div
+                        className="top-list-bar"
+                        style={{ width: `${(location.sessions / mostSessions) * 100}%` }}
+                    />
+                </div>
+                <div className="top-list-meta">
+                    {this.formatCount(location.sets)} sets · {this.formatCount(location.repetitions)} reps · {this.formatWeight(location.volume_kg)}
+                </div>
+            </li>
+        ))
+    }
+
     render(): React.ReactNode {
+        const latestSets = this.getLatestSets()
+        const bestSet = this.getBestSet()
+
         if (this.state.showDeleteConfirm) {
             return (
                 <div className="center-container-grid">
@@ -475,6 +704,214 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
                                     </div>
                                 </div>
                             </div>
+                            </div>
+
+                            <div className="detail-section stats-section">
+                                <h3>🕒 Latest Workout</h3>
+
+                                {this.state.setsLoading && (
+                                    <div className="detail-card">
+                                        <p>Loading latest workout...</p>
+                                    </div>
+                                )}
+
+                                {this.state.setsError && (
+                                    <div className="detail-card">
+                                        <p className="error-message">{this.state.setsError}</p>
+                                    </div>
+                                )}
+
+                                {!this.state.setsLoading && !this.state.setsError && this.state.exerciseSets && (
+                                    latestSets.length === 0 ? (
+                                        <div className="detail-card">
+                                            <p>This exercise has not been logged yet.</p>
+                                        </div>
+                                    ) : (
+                                        <div className="detail-card">
+                                            <div className="latest-workout-meta">
+                                                <span className="latest-workout-date">
+                                                    {this.formatSessionDate(latestSets[0].workout_time)}
+                                                </span>
+                                                {this.state.locationNames[latestSets[0].location_id] && (
+                                                    <a
+                                                        className="latest-workout-location"
+                                                        href={`/go-heavier/locations/${latestSets[0].location_id}`}
+                                                        onClick={(e) => {
+                                                            e.preventDefault()
+                                                            this.props.navigate(`/go-heavier/locations/${latestSets[0].location_id}`)
+                                                        }}
+                                                    >
+                                                        📍 {this.state.locationNames[latestSets[0].location_id]}
+                                                    </a>
+                                                )}
+                                                <span className="latest-workout-count">
+                                                    {latestSets.length} {latestSets.length === 1 ? "set" : "sets"}
+                                                </span>
+                                            </div>
+
+                                            <div className="set-table-wrapper">
+                                                <table className="set-table">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Set</th>
+                                                            <th>Reps</th>
+                                                            <th>Weight</th>
+                                                            <th>Bar</th>
+                                                            <th>Supp.</th>
+                                                            <th>Total</th>
+                                                            <th>Notes</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        {latestSets.map((set) => {
+                                                            const total = set.weight_kg +
+                                                                (set.bar_weight_kg || 0) +
+                                                                (set.supplementary_weight_kg || 0)
+                                                            return (
+                                                                <tr key={set.id}>
+                                                                    <td>{set.index}</td>
+                                                                    <td>{set.repetitions}</td>
+                                                                    <td>{set.weight_kg.toFixed(1)}</td>
+                                                                    <td>{set.bar_weight_kg ? set.bar_weight_kg.toFixed(1) : "-"}</td>
+                                                                    <td>{set.supplementary_weight_kg ? set.supplementary_weight_kg.toFixed(1) : "-"}</td>
+                                                                    <td><strong>{total.toFixed(1)}</strong></td>
+                                                                    <td className="set-notes">{formatNotes(set.notes)}</td>
+                                                                </tr>
+                                                            )
+                                                        })}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                    )
+                                )}
+                            </div>
+
+                            <div className="detail-section stats-section">
+                                <h3>🏆 Best Set</h3>
+
+                                {this.state.setsLoading && (
+                                    <div className="detail-card">
+                                        <p>Loading best set...</p>
+                                    </div>
+                                )}
+
+                                {this.state.setsError && (
+                                    <div className="detail-card">
+                                        <p className="error-message">{this.state.setsError}</p>
+                                    </div>
+                                )}
+
+                                {!this.state.setsLoading && !this.state.setsError && this.state.exerciseSets && (
+                                    bestSet === null ? (
+                                        <div className="detail-card">
+                                            <p>This exercise has not been logged yet.</p>
+                                        </div>
+                                    ) : (
+                                        <div className="detail-card">
+                                            <div className="best-set-headline">
+                                                <span className="best-set-weight">{bestSet.weight_kg.toFixed(1)} kg</span>
+                                                <span className="best-set-reps">× {bestSet.repetitions} reps</span>
+                                            </div>
+                                            <div className="best-set-meta">
+                                                <span>{this.formatSessionDate(bestSet.workout_time)}</span>
+                                                {this.state.locationNames[bestSet.location_id] && (
+                                                    <a
+                                                        className="latest-workout-location"
+                                                        href={`/go-heavier/locations/${bestSet.location_id}`}
+                                                        onClick={(e) => {
+                                                            e.preventDefault()
+                                                            this.props.navigate(`/go-heavier/locations/${bestSet.location_id}`)
+                                                        }}
+                                                    >
+                                                        📍 {this.state.locationNames[bestSet.location_id]}
+                                                    </a>
+                                                )}
+                                                <span>Set {bestSet.index}</span>
+                                            </div>
+                                            {formatNotes(bestSet.notes) && (
+                                                <p className="best-set-notes">{formatNotes(bestSet.notes)}</p>
+                                            )}
+                                        </div>
+                                    )
+                                )}
+                            </div>
+
+                            <div className="detail-section stats-section">
+                                <h3>📊 Stats</h3>
+
+                                {this.state.statsLoading && (
+                                    <div className="detail-card">
+                                        <p>Loading stats...</p>
+                                    </div>
+                                )}
+
+                                {this.state.statsError && (
+                                    <div className="detail-card">
+                                        <p className="error-message">{this.state.statsError}</p>
+                                    </div>
+                                )}
+
+                                {!this.state.statsLoading && !this.state.statsError && this.state.stats && (
+                                    <>
+                                        <div className="stats-grid">
+                                            <div className="stat-tile">
+                                                <div className="stat-tile-value">{this.formatCount(this.state.stats.sessions)}</div>
+                                                <div className="stat-tile-label">Sessions</div>
+                                            </div>
+                                            <div className="stat-tile">
+                                                <div className="stat-tile-value">{this.formatCount(this.state.stats.total_sets)}</div>
+                                                <div className="stat-tile-label">Sets</div>
+                                            </div>
+                                            <div className="stat-tile">
+                                                <div className="stat-tile-value">{this.formatCount(this.state.stats.total_repetitions)}</div>
+                                                <div className="stat-tile-label">Reps</div>
+                                            </div>
+                                            <div className="stat-tile">
+                                                <div className="stat-tile-value">{this.formatWeight(this.state.stats.total_volume_kg)}</div>
+                                                <div className="stat-tile-label">Total volume</div>
+                                            </div>
+                                            <div className="stat-tile">
+                                                <div className="stat-tile-value">{this.formatWeight(this.state.stats.heaviest_weight_kg)}</div>
+                                                <div className="stat-tile-label">Heaviest lift</div>
+                                            </div>
+                                            <div className="stat-tile">
+                                                <div className="stat-tile-value">{this.formatCount(this.state.stats.distinct_locations)}</div>
+                                                <div className="stat-tile-label">Locations</div>
+                                            </div>
+                                        </div>
+
+                                        <div className="stats-detail">
+                                            <div className="detail-card">
+                                                <div className="info-row">
+                                                    <span className="info-label">First performed:</span>
+                                                    <span className="info-value">{this.formatPerformedDate(this.state.stats.first_performed)}</span>
+                                                </div>
+                                                <div className="info-row">
+                                                    <span className="info-label">Last performed:</span>
+                                                    <span className="info-value">{this.formatPerformedDate(this.state.stats.last_performed)}</span>
+                                                </div>
+                                                <div className="info-row">
+                                                    <span className="info-label">Sets per session:</span>
+                                                    <span className="info-value">{this.state.stats.average_sets_per_session.toFixed(1)}</span>
+                                                </div>
+                                                <div className="info-row">
+                                                    <span className="info-label">Reps per set:</span>
+                                                    <span className="info-value">{this.state.stats.average_repetitions_per_set.toFixed(1)}</span>
+                                                </div>
+                                            </div>
+
+                                            {(this.state.stats.top_locations ?? []).length > 0 && (
+                                                <div className="detail-card">
+                                                    <h4 className="top-list-title">Top locations by sessions</h4>
+                                                    <ol className="top-list">
+                                                        {this.renderTopLocations(this.state.stats.top_locations ?? [])}
+                                                    </ol>
+                                                </div>
+                                            )}
+                                        </div>
+                                    </>
+                                )}
                             </div>
                         </div>
                     )}

--- a/src/pages/go_heavier/ExerciseDetail.tsx
+++ b/src/pages/go_heavier/ExerciseDetail.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
-import { API_URL, formatNotes } from "../../configs"
+import { API_URL, WORKOUTS_CACHE_KEY, formatNotes } from "../../configs"
 import "../../components/go_heavier/Stats.css"
 import "./ExerciseDetail.css"
 import "../go_heavier/Exercises.css"
@@ -142,35 +142,14 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
 
     // Every set of this exercise, needed for the latest session and the best set.
     // The workouts endpoint's exercise_id filter currently returns a 500, so the
-    // pages are walked and matched here. Swap to ?exercise_id= once the API is fixed.
-    fetchExerciseSets = async () => {
+    // whole list is matched here. Swap to ?exercise_id= once the API is fixed.
+    fetchExerciseSets = async (useCache: boolean = true) => {
         this.setState({ setsLoading: true, setsError: null })
         try {
-            const workouts: WorkoutSet[] = []
-            const batchSize = 4
-            let page = 1
-            let exhausted = false
-
-            while (!exhausted && page <= MAX_WORKOUT_PAGES) {
-                const firstPage = page
-                const pageNumbers = Array.from({ length: batchSize }, (_, offset) => firstPage + offset)
-                const responses = await Promise.all(
-                    pageNumbers.map(pageNumber => fetch(`${API_URL}/go-heavier/workouts?page=${pageNumber}`))
-                )
-
-                for (const response of responses) {
-                    if (!response.ok) {
-                        throw new Error("Failed to load workouts")
-                    }
-                    const pageWorkouts: WorkoutSet[] = await response.json()
-                    if (pageWorkouts.length === 0) {
-                        exhausted = true
-                    } else {
-                        workouts.push(...pageWorkouts)
-                    }
-                }
-                page += batchSize
-            }
+            // The workouts page caches every page it fetched, so arriving from there
+            // costs nothing. Refreshing always goes back to the API.
+            const cached = useCache ? localStorage.getItem(WORKOUTS_CACHE_KEY) : null
+            const workouts: WorkoutSet[] = cached ? JSON.parse(cached) : await this.fetchAllWorkouts()
 
             const exerciseSets = workouts.filter(workout => workout.exercise_id === this.props.id)
             this.setState({ exerciseSets, setsLoading: false })
@@ -178,6 +157,36 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
             console.error("Error fetching workouts for this exercise:", error)
             this.setState({ setsError: (error as Error).message, setsLoading: false })
         }
+    }
+
+    fetchAllWorkouts = async (): Promise<WorkoutSet[]> => {
+        const workouts: WorkoutSet[] = []
+        const batchSize = 4
+        let page = 1
+        let exhausted = false
+
+        while (!exhausted && page <= MAX_WORKOUT_PAGES) {
+            const firstPage = page
+            const pageNumbers = Array.from({ length: batchSize }, (_, offset) => firstPage + offset)
+            const responses = await Promise.all(
+                pageNumbers.map(pageNumber => fetch(`${API_URL}/go-heavier/workouts?page=${pageNumber}`))
+            )
+
+            for (const response of responses) {
+                if (!response.ok) {
+                    throw new Error("Failed to load workouts")
+                }
+                const pageWorkouts: WorkoutSet[] = await response.json()
+                if (pageWorkouts.length === 0) {
+                    exhausted = true
+                } else {
+                    workouts.push(...pageWorkouts)
+                }
+            }
+            page += batchSize
+        }
+
+        return workouts
     }
 
 
@@ -226,7 +235,7 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
     handleRefresh = async () => {
         this.setState({ isRefreshing: true })
         this.fetchStats()
-        this.fetchExerciseSets()
+        this.fetchExerciseSets(false)
         try {
             const response = await fetch(`${API_URL}/go-heavier/exercises/${this.props.id}`)
             if (!response.ok) {

--- a/src/pages/go_heavier/LocationDetail.css
+++ b/src/pages/go_heavier/LocationDetail.css
@@ -90,6 +90,26 @@
     box-shadow: 0 4px 16px rgba(102, 126, 234, 0.3);
 }
 
+.location-detail-logo {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+    border-radius: 12px;
+    padding: 12px 16px;
+    margin-bottom: 20px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.location-detail-logo img {
+    display: block;
+    max-height: 80px;
+    max-width: 220px;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+}
+
 .location-detail-header h1 {
     margin: 0 0 16px 0;
     font-size: 2.5rem;

--- a/src/pages/go_heavier/LocationDetail.tsx
+++ b/src/pages/go_heavier/LocationDetail.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import { API_URL, countryCodeToEmoji } from "../../configs"
+import "../../components/go_heavier/Stats.css"
 import "./LocationDetail.css"
 import "../go_heavier/Locations.css"
 import "../../components/go_heavier/LocationForm.css"
@@ -15,12 +16,41 @@ interface LocationData {
     address_city: string
     address_country_iso3: string
     address_postal_code: string
+    logo_url: string
     created_at: string
     updated_at: string
 }
 
+interface TopExercise {
+    exercise_id: string
+    name: string
+    visits: number
+    sets: number
+    repetitions: number
+    volume_kg: number
+}
+
+interface LocationStatsData {
+    location_id: string
+    name: string
+    visits: number
+    first_visit: string | null
+    last_visit: string | null
+    total_sets: number
+    total_repetitions: number
+    total_volume_kg: number
+    heaviest_weight_kg: number | null
+    average_sets_per_visit: number
+    average_exercises_per_visit: number
+    distinct_exercises: number
+    top_exercises?: TopExercise[]
+}
+
 interface State {
     location: LocationData | null
+    stats: LocationStatsData | null
+    statsLoading: boolean
+    statsError: string | null
     loading: boolean
     error: string | null
     isRefreshing: boolean
@@ -34,6 +64,7 @@ interface State {
         address_city: string
         address_country_iso3: string
         address_postal_code: string
+        logo_url: string
     }
     formLoading: boolean
     formError: string | null
@@ -44,6 +75,9 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
         super(props)
         this.state = {
             location: null,
+            stats: null,
+            statsLoading: true,
+            statsError: null,
             loading: true,
             error: null,
             isRefreshing: false,
@@ -56,7 +90,8 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
                 address_line2: "",
                 address_city: "",
                 address_country_iso3: "",
-                address_postal_code: ""
+                address_postal_code: "",
+                logo_url: ""
             },
             formLoading: false,
             formError: null
@@ -65,6 +100,22 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
 
     componentDidMount() {
         this.fetchLocation()
+        this.fetchStats()
+    }
+
+    fetchStats = async () => {
+        this.setState({ statsLoading: true, statsError: null })
+        try {
+            const response = await fetch(`${API_URL}/go-heavier/locations/${this.props.id}/stats`)
+            if (!response.ok) {
+                throw new Error("Failed to load stats")
+            }
+            const stats = await response.json()
+            this.setState({ stats, statsLoading: false })
+        } catch (error) {
+            console.error("Error fetching location stats:", error)
+            this.setState({ statsError: (error as Error).message, statsLoading: false })
+        }
     }
 
     fetchLocation = async () => {
@@ -85,7 +136,8 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
                     address_line2: result.address_line2,
                     address_city: result.address_city,
                     address_country_iso3: result.address_country_iso3,
-                    address_postal_code: result.address_postal_code
+                    address_postal_code: result.address_postal_code,
+                    logo_url: result.logo_url || ""
                 }
             })
         } catch (error) {
@@ -96,6 +148,7 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
 
     handleRefresh = async () => {
         this.setState({ isRefreshing: true })
+        this.fetchStats()
         try {
             const response = await fetch(`${API_URL}/go-heavier/locations/${this.props.id}`)
             if (!response.ok) {
@@ -156,7 +209,8 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
                 address_line2: this.state.location.address_line2,
                 address_city: this.state.location.address_city,
                 address_country_iso3: this.state.location.address_country_iso3,
-                address_postal_code: this.state.location.address_postal_code
+                address_postal_code: this.state.location.address_postal_code,
+                logo_url: this.state.location.logo_url || ""
             },
             formError: null
         })
@@ -170,7 +224,7 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
     }
 
     validateForm = (): boolean => {
-        const { name, address_line1, address_city, address_country_iso3, address_postal_code } = this.state.formData
+        const { name, address_line1, address_city, address_country_iso3, address_postal_code, logo_url } = this.state.formData
 
         if (!name.trim()) {
             this.setState({ formError: "Name is required" })
@@ -200,6 +254,15 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
         if (!address_postal_code.trim()) {
             this.setState({ formError: "Postal code is required" })
             return false
+        }
+
+        if (logo_url.trim()) {
+            try {
+                new URL(logo_url.trim())
+            } catch {
+                this.setState({ formError: "Logo URL must be a valid URL" })
+                return false
+            }
         }
 
         return true
@@ -240,6 +303,56 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
         } catch (err) {
             this.setState({ formError: (err as Error).message, formLoading: false })
         }
+    }
+
+    formatCount = (value: number): string => value.toLocaleString()
+
+    formatWeight = (value: number | null): string =>
+        value === null || value === undefined ? "\u2014" : `${Math.round(value).toLocaleString()} kg`
+
+    formatVisitDate = (value: string | null): string => {
+        if (!value) {
+            return "\u2014"
+        }
+        return new Date(value).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric"
+        })
+    }
+
+    // The bar length encodes visits, the same measure the list is ordered by.
+    renderTopExercises = (topExercises: TopExercise[]): React.ReactNode => {
+        const mostVisits = Math.max(...topExercises.map(exercise => exercise.visits), 1)
+
+        return topExercises.map((exercise) => (
+            <li key={exercise.exercise_id} className="top-list-item">
+                <div className="top-list-head">
+                    <a
+                        className="top-list-name"
+                        href={`/go-heavier/exercises/${exercise.exercise_id}`}
+                        onClick={(e) => {
+                            e.preventDefault()
+                            this.props.navigate(`/go-heavier/exercises/${exercise.exercise_id}`)
+                        }}
+                    >
+                        {exercise.name}
+                    </a>
+                    <span className="top-list-metric">
+                        {this.formatCount(exercise.visits)} visits
+                    </span>
+                </div>
+                <div className="top-list-bar-track">
+                    <div
+                        className="top-list-bar"
+                        style={{ width: `${(exercise.visits / mostVisits) * 100}%` }}
+                    />
+                </div>
+                <div className="top-list-meta">
+                    {this.formatCount(exercise.sets)} sets · {this.formatCount(exercise.repetitions)} reps · {this.formatWeight(exercise.volume_kg)}
+                </div>
+            </li>
+        ))
     }
 
     render(): React.ReactNode {
@@ -355,6 +468,16 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
                                             required
                                         />
                                     </label>
+                                    <label>
+                                        Logo URL:
+                                        <input
+                                            type="url"
+                                            name="logo_url"
+                                            value={this.state.formData.logo_url}
+                                            onChange={this.handleChange}
+                                            placeholder="https://..."
+                                        />
+                                    </label>
                                     {this.state.formError && <p className="error-message">{this.state.formError}</p>}
                                     <div className="form-actions">
                                         <button type="submit" disabled={this.state.formLoading}>
@@ -408,6 +531,11 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
                     {this.state.location && (
                         <div className={`location-detail-container ${this.state.isRefreshing ? 'refreshing' : ''}`}>
                             <div className="location-detail-header">
+                                {this.state.location.logo_url && (
+                                    <div className="location-detail-logo">
+                                        <img src={this.state.location.logo_url} alt={`${this.state.location.name} logo`} />
+                                    </div>
+                                )}
                                 <h1>{this.state.location.name} {countryCodeToEmoji(this.state.location.address_country_iso3.substring(0, 2))}</h1>
                                 <p className="location-detail-description">{this.state.location.description}</p>
                                 <div className="action-buttons">
@@ -421,6 +549,83 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
                             </div>
 
                             <div className="location-detail-content">
+                                <div className="detail-section stats-section">
+                                    <h3>📊 Stats</h3>
+
+                                    {this.state.statsLoading && (
+                                        <div className="detail-card">
+                                            <p>Loading stats...</p>
+                                        </div>
+                                    )}
+
+                                    {this.state.statsError && (
+                                        <div className="detail-card">
+                                            <p className="error-message">{this.state.statsError}</p>
+                                        </div>
+                                    )}
+
+                                    {!this.state.statsLoading && !this.state.statsError && this.state.stats && (
+                                        <>
+                                            <div className="stats-grid">
+                                                <div className="stat-tile">
+                                                    <div className="stat-tile-value">{this.formatCount(this.state.stats.visits)}</div>
+                                                    <div className="stat-tile-label">Visits</div>
+                                                </div>
+                                                <div className="stat-tile">
+                                                    <div className="stat-tile-value">{this.formatCount(this.state.stats.total_sets)}</div>
+                                                    <div className="stat-tile-label">Sets</div>
+                                                </div>
+                                                <div className="stat-tile">
+                                                    <div className="stat-tile-value">{this.formatCount(this.state.stats.total_repetitions)}</div>
+                                                    <div className="stat-tile-label">Reps</div>
+                                                </div>
+                                                <div className="stat-tile">
+                                                    <div className="stat-tile-value">{this.formatWeight(this.state.stats.total_volume_kg)}</div>
+                                                    <div className="stat-tile-label">Total volume</div>
+                                                </div>
+                                                <div className="stat-tile">
+                                                    <div className="stat-tile-value">{this.formatWeight(this.state.stats.heaviest_weight_kg)}</div>
+                                                    <div className="stat-tile-label">Heaviest lift</div>
+                                                </div>
+                                                <div className="stat-tile">
+                                                    <div className="stat-tile-value">{this.formatCount(this.state.stats.distinct_exercises)}</div>
+                                                    <div className="stat-tile-label">Exercises</div>
+                                                </div>
+                                            </div>
+
+                                            <div className="stats-detail">
+                                                <div className="detail-card">
+                                                    <div className="info-row">
+                                                        <span className="info-label">First visit:</span>
+                                                        <span className="info-value">{this.formatVisitDate(this.state.stats.first_visit)}</span>
+                                                    </div>
+                                                    <div className="info-row">
+                                                        <span className="info-label">Last visit:</span>
+                                                        <span className="info-value">{this.formatVisitDate(this.state.stats.last_visit)}</span>
+                                                    </div>
+                                                    <div className="info-row">
+                                                        <span className="info-label">Sets per visit:</span>
+                                                        <span className="info-value">{this.state.stats.average_sets_per_visit.toFixed(1)}</span>
+                                                    </div>
+                                                    <div className="info-row">
+                                                        <span className="info-label">Exercises per visit:</span>
+                                                        <span className="info-value">{this.state.stats.average_exercises_per_visit.toFixed(1)}</span>
+                                                    </div>
+                                                </div>
+
+                                                {(this.state.stats.top_exercises ?? []).length > 0 && (
+                                                    <div className="detail-card">
+                                                        <h4 className="top-list-title">Top exercises by visits</h4>
+                                                        <ol className="top-list">
+                                                            {this.renderTopExercises(this.state.stats.top_exercises ?? [])}
+                                                        </ol>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </>
+                                    )}
+                                </div>
+
                                 <div className="detail-section">
                                     <h3>📍 Address</h3>
                                     <div className="detail-card">

--- a/src/pages/go_heavier/Workouts.css
+++ b/src/pages/go_heavier/Workouts.css
@@ -375,38 +375,7 @@
     }
 }
 
-/* Loading more indicator */
-.loading-more {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 12px;
-    padding: 32px 20px;
-    color: #667eea;
-    font-weight: 600;
-    font-size: 1rem;
-}
-
-.loading-more .spinner {
-    width: 24px;
-    height: 24px;
-    border: 3px solid rgba(102, 126, 234, 0.2);
-    border-top-color: #667eea;
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
-}
-
 @keyframes spin {
     to { transform: rotate(360deg); }
 }
 
-/* No more data indicator */
-.no-more-data {
-    text-align: center;
-    padding: 24px 20px;
-    color: #718096;
-    font-size: 0.95rem;
-    font-weight: 500;
-    border-top: 1px solid rgba(0, 0, 0, 0.06);
-    background: rgba(102, 126, 234, 0.03);
-}

--- a/src/pages/go_heavier/Workouts.tsx
+++ b/src/pages/go_heavier/Workouts.tsx
@@ -1,8 +1,9 @@
 import React from "react"
-import { useSearchParams } from "react-router-dom"
+import { useNavigate, useSearchParams } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import WorkoutForm from "../../components/go_heavier/WorkoutForm"
-import { API_URL, formatNotes } from "../../configs"
+import { API_URL, WORKOUTS_CACHE_KEY, formatNotes } from "../../configs"
+import "../GoHeavier.css"
 import "./Workouts.css"
 
 interface WorkoutData {
@@ -21,7 +22,6 @@ interface WorkoutData {
     updated_at: string
 }
 
-const WORKOUTS_CACHE_KEY = 'go-heavier-workouts'
 // Safety cap on the page walk so a misbehaving endpoint can't loop forever.
 const MAX_WORKOUT_PAGES = 500
 
@@ -62,6 +62,7 @@ interface State {
 interface WorkoutsProps {
     searchParams: URLSearchParams
     setSearchParams: (params: URLSearchParams) => void
+    navigate: (path: string) => void
 }
 
 export class Workouts extends React.Component<WorkoutsProps, State> {
@@ -128,7 +129,12 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         return dedupeById(all)
     }
 
-    handleRefresh = async () => {
+    fetchWorkouts = async (minDuration: number = 300) => {
+        const startedAt = Date.now()
+        const waitOut = () => new Promise<void>(resolve =>
+            setTimeout(resolve, Math.max(0, minDuration - (Date.now() - startedAt)))
+        )
+
         this.setState({ isRefreshing: true })
         try {
             const [workouts, locationsRes, exercisesRes] = await Promise.all([
@@ -142,20 +148,29 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
             
             localStorage.setItem(WORKOUTS_CACHE_KEY, JSON.stringify(workouts))
             
-            setTimeout(() => {
-                this.setState({ 
-                    workouts, 
-                    locations,
-                    exercises,
-                    configLoaded: true, 
-                    isRefreshing: false,
-                    hasFetchedOnce: true
-                })
-            }, 300)
+            await waitOut()
+            this.setState({ 
+                workouts, 
+                locations,
+                exercises,
+                configLoaded: true, 
+                isRefreshing: false,
+                hasFetchedOnce: true
+            })
         } catch (error) {
             console.error("Error fetching workouts:", error)
+            await waitOut()
             this.setState({ configLoaded: false, isRefreshing: false })
         }
+    }
+
+    handleRefresh = () => {
+        this.fetchWorkouts()
+    }
+
+    handleRetry = () => {
+        // Keep the loading state on screen long enough to be visible
+        this.fetchWorkouts(1000)
     }
 
     componentDidMount() {
@@ -351,7 +366,7 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
             case true:
                 return <></>
             case false:
-                return <p className="error-message">Failed to load workouts</p>
+                return <></>
             default:
                 return (
                     <div className="loading-spinner">
@@ -384,10 +399,22 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                     )}
                     <div className="header">
                         {this.showLoading()}
-                        {!this.state.configLoaded && this.state.configLoaded !== null && (
-                            <button onClick={this.handleRefresh}>Retry</button>
-                        )}
                     </div>
+
+                    {this.state.configLoaded === false && (
+                        <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
+                            <h2>Failed to Load Workouts</h2>
+                            <p className="error-message">Unable to fetch workouts from server</p>
+                            <button onClick={this.handleRetry} disabled={this.state.isRefreshing}>
+                                {this.state.isRefreshing ? (
+                                    <>
+                                        <span className="button-spinner"></span>
+                                        Retrying...
+                                    </>
+                                ) : 'Retry'}
+                            </button>
+                        </div>
+                    )}
 
                     {this.state.configLoaded && this.state.workouts != null && filteredWorkouts.length === 0 && (
                         <div className="header">
@@ -530,7 +557,7 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                                                         href={`/go-heavier/exercises/${workout.exercise_id}`}
                                                         onClick={(e) => {
                                                             e.preventDefault()
-                                                            window.location.href = `/go-heavier/exercises/${workout.exercise_id}`
+                                                            this.props.navigate(`/go-heavier/exercises/${workout.exercise_id}`)
                                                         }}
                                                         className="table-link"
                                                     >
@@ -542,7 +569,7 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                                                         href={`/go-heavier/locations/${workout.location_id}`}
                                                         onClick={(e) => {
                                                             e.preventDefault()
-                                                            window.location.href = `/go-heavier/locations/${workout.location_id}`
+                                                            this.props.navigate(`/go-heavier/locations/${workout.location_id}`)
                                                         }}
                                                         className="table-link"
                                                     >
@@ -619,5 +646,6 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
 // Wrapper component to provide URL search params
 export default function WorkoutsWithParams() {
     const [searchParams, setSearchParams] = useSearchParams()
-    return <Workouts searchParams={searchParams} setSearchParams={setSearchParams} />
+    const navigate = useNavigate()
+    return <Workouts searchParams={searchParams} setSearchParams={setSearchParams} navigate={navigate} />
 }

--- a/src/pages/go_heavier/Workouts.tsx
+++ b/src/pages/go_heavier/Workouts.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { useSearchParams } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import WorkoutForm from "../../components/go_heavier/WorkoutForm"
-import { API_URL } from "../../configs"
+import { API_URL, formatNotes } from "../../configs"
 import "./Workouts.css"
 
 interface WorkoutData {
@@ -20,6 +20,19 @@ interface WorkoutData {
     created_at: string
     updated_at: string
 }
+
+const WORKOUTS_CACHE_KEY = 'go-heavier-workouts'
+// Safety cap on the page walk so a misbehaving endpoint can't loop forever.
+const MAX_WORKOUT_PAGES = 500
+
+// Pagination is offset-based, so a page can overlap another when rows are
+// inserted between requests. Always merge on id rather than concatenating.
+const mergeById = (existing: WorkoutData[], incoming: WorkoutData[]): WorkoutData[] => {
+    const seen = new Set(existing.map(workout => workout.id))
+    return [...existing, ...incoming.filter(workout => !seen.has(workout.id))]
+}
+
+const dedupeById = (workouts: WorkoutData[]): WorkoutData[] => mergeById([], workouts)
 
 interface State {
     configLoaded: boolean | null
@@ -44,9 +57,6 @@ interface State {
         exerciseIds: string[]
         locationIds: string[]
     }
-    currentPage: number
-    hasMore: boolean
-    isLoadingMore: boolean
 }
 
 interface WorkoutsProps {
@@ -60,8 +70,8 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
     constructor(props: WorkoutsProps) {
         super(props)
         
-        const cachedData = localStorage.getItem('go-heavier-workouts')
-        const cachedWorkouts = cachedData ? JSON.parse(cachedData) : undefined
+        const cachedData = localStorage.getItem(WORKOUTS_CACHE_KEY)
+        const cachedWorkouts = cachedData ? dedupeById(JSON.parse(cachedData)) : undefined
         
         // Read filters from URL
         const startDate = props.searchParams.get('startDate') || ''
@@ -90,10 +100,7 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
             filters: {
                 exerciseIds,
                 locationIds
-            },
-            currentPage: 1,
-            hasMore: true,
-            isLoadingMore: false
+            }
         }
     }
 
@@ -104,20 +111,36 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         }, 3000)
     }
 
+    // The API pages its results, so walk pages until one comes back empty.
+    fetchAllWorkouts = async (): Promise<WorkoutData[]> => {
+        const all: WorkoutData[] = []
+
+        for (let page = 1; page <= MAX_WORKOUT_PAGES; page++) {
+            const response = await fetch(`${API_URL}/go-heavier/workouts?page=${page}`)
+            const pageWorkouts: WorkoutData[] = await response.json()
+
+            if (pageWorkouts.length === 0) {
+                break
+            }
+            all.push(...pageWorkouts)
+        }
+
+        return dedupeById(all)
+    }
+
     handleRefresh = async () => {
-        this.setState({ isRefreshing: true, currentPage: 1, hasMore: true })
+        this.setState({ isRefreshing: true })
         try {
-            const [workoutsRes, locationsRes, exercisesRes] = await Promise.all([
-                fetch(`${API_URL}/go-heavier/workouts?page=1`),
+            const [workouts, locationsRes, exercisesRes] = await Promise.all([
+                this.fetchAllWorkouts(),
                 fetch(`${API_URL}/go-heavier/locations`),
                 fetch(`${API_URL}/go-heavier/exercises`)
             ])
             
-            const workouts = await workoutsRes.json()
             const locations = await locationsRes.json()
             const exercises = await exercisesRes.json()
             
-            localStorage.setItem('go-heavier-workouts', JSON.stringify(workouts))
+            localStorage.setItem(WORKOUTS_CACHE_KEY, JSON.stringify(workouts))
             
             setTimeout(() => {
                 this.setState({ 
@@ -126,8 +149,7 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                     exercises,
                     configLoaded: true, 
                     isRefreshing: false,
-                    hasFetchedOnce: true,
-                    hasMore: workouts.length > 0
+                    hasFetchedOnce: true
                 })
             }, 300)
         } catch (error) {
@@ -142,59 +164,6 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         } else {
             // If workouts are cached, still need to fetch locations and exercises for name lookup
             this.fetchLocationsAndExercises()
-        }
-        
-        // Add scroll listener for infinite scroll
-        window.addEventListener('scroll', this.handleScroll)
-    }
-
-    componentWillUnmount() {
-        window.removeEventListener('scroll', this.handleScroll)
-    }
-
-    handleScroll = () => {
-        // Check if we're near the bottom of the page
-        const scrollPosition = window.innerHeight + window.scrollY
-        const pageHeight = document.documentElement.scrollHeight
-        const threshold = 300 // pixels from bottom to trigger load
-        
-        if (scrollPosition >= pageHeight - threshold && 
-            !this.state.isLoadingMore && 
-            this.state.hasMore && 
-            this.state.configLoaded) {
-            this.loadMoreWorkouts()
-        }
-    }
-
-    loadMoreWorkouts = async () => {
-        this.setState({ isLoadingMore: true })
-        const nextPage = this.state.currentPage + 1
-        
-        try {
-            const response = await fetch(`${API_URL}/go-heavier/workouts?page=${nextPage}`)
-            const newWorkouts = await response.json()
-            
-            if (newWorkouts.length === 0) {
-                // No more data
-                this.setState({ 
-                    isLoadingMore: false, 
-                    hasMore: false 
-                })
-            } else {
-                // Append new workouts to existing ones
-                const allWorkouts = [...(this.state.workouts || []), ...newWorkouts]
-                localStorage.setItem('go-heavier-workouts', JSON.stringify(allWorkouts))
-                
-                this.setState({ 
-                    workouts: allWorkouts,
-                    currentPage: nextPage,
-                    isLoadingMore: false,
-                    hasMore: newWorkouts.length > 0
-                })
-            }
-        } catch (error) {
-            console.error("Error loading more workouts:", error)
-            this.setState({ isLoadingMore: false })
         }
     }
 
@@ -599,26 +568,13 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                                                     <strong>{totalWeight.toFixed(1)}</strong>
                                                 </td>
                                                 <td className="workout-notes">
-                                                    {workout.notes || '-'}
+                                                    {formatNotes(workout.notes)}
                                                 </td>
                                             </tr>
                                         )
                                     })}
                                 </tbody>
                             </table>
-                            
-                            {this.state.isLoadingMore && (
-                                <div className="loading-more">
-                                    <div className="spinner"></div>
-                                    <span>Loading more workouts...</span>
-                                </div>
-                            )}
-                            
-                            {!this.state.hasMore && this.state.workouts && this.state.workouts.length > 0 && (
-                                <div className="no-more-data">
-                                    ✓ All workouts loaded ({this.state.workouts.length} total)
-                                </div>
-                            )}
                         </div>
                     )}
                     {this.state.configLoaded && (
@@ -638,9 +594,10 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                                 onClose={() => {
                                     this.setState({ showForm: false })
                                 }}
-                                onSuccess={(newWorkout) => {
-                                    this.state.workouts?.push(newWorkout)
-                                    localStorage.removeItem('go-heavier-workouts')
+                                onSuccess={() => {
+                                    // handleRefresh below repopulates from page 1,
+                                    // which already includes the new workout.
+                                    localStorage.removeItem(WORKOUTS_CACHE_KEY)
                                     this.setState({ showForm: false })
                                     this.showToast("Workout created successfully", 'success')
                                     this.handleRefresh()


### PR DESCRIPTION
## Summary

Three commits of Go Heavier work.

### Dashboard and workouts fixes (`5547324`)

- Retrying a failed load greys the panel and shows a spinner, held for at least a second so the request is visible when the API is unreachable.
- Workouts page fetches every page up front; infinite scroll removed.
- Workouts rows are deduped by id. Three separate causes: the cached page counter resetting on reload, overlapping pages, and a direct state mutation on create.
- Notes render blank instead of the API's literal `"NaN"` placeholder.

### Locations and exercises (`7d1772b`)

- Location gains `logo_url` (named to match the API), rendered on the location cards and the location detail page, and editable in both edit forms.
- Dashboard stat cards link through to Locations / Exercises / Workouts.
- Location and exercise detail pages get a stats section from the `/stats` endpoints: KPI tiles, averages, and a ranked breakdown (top exercises per location, top locations per exercise). Shared presentation lives in `src/components/go_heavier/Stats.css`.
- Exercise detail also shows the latest session — every set logged that day — and the best set, defined as the heaviest lift so it agrees with the "Heaviest lift" tile.

### Simpler dashboard, less redundant loading (`642cbb5`)

- The workouts retry state now matches the dashboard's: greyed panel, spinner, and the minimum duration honoured on the failure path too. Previously a failed retry flashed and reverted with nothing visible.
- The workouts table navigated with `window.location.href`, which reloads the whole SPA and refetches every page's data. It now navigates client side like the rest of the app.
- The exercise detail page reuses the workout list the workouts page already cached instead of walking all 16 pages on every visit. Refresh still goes back to the API.
- Countries, muscle groups, and specific muscles are gone from the dashboard, which also drops the `/config` request that only fed them. The hero now describes what the service is, and the three remaining cards are larger with a caption each.
- Removing those cards also removed a set of `.tag` rules in `GoHeavier.css` that collided with the ones in `Exercise.css` — which won depended on bundle order.

## Known API issues

Neither is caused by this PR, but both shape the code:

1. `GET /go-heavier/workouts?exercise_id=…` returns a 500, as does `?location_id=…`. A bogus value correctly returns 422, so validation passes and the handler then fails. `?after=`, `?before=`, and `?page=` are fine. The exercise page therefore filters client side; fixing the filter collapses that into a single request. The workaround is marked with a comment at `fetchExerciseSets`.
2. `/go-heavier/workouts/stats` reports `total_sets: 1261`, but paging through `/go-heavier/workouts` yields 795 rows (15 full pages plus 45). The dashboard tile deliberately uses the paged count so it agrees with the workouts page, but the two endpoints disagreeing is worth chasing.

## Testing

- `tsc --noEmit` and `eslint` clean.
- `CI=true react-scripts build` compiles successfully with no warnings.
- Stats, latest session, and best set verified against the local API: Overhead Press resolves to 43 sets, latest day Fri 22 May 2026 (2 sets), best set 25 kg × 5 reps — matching the endpoint's own `heaviest_weight_kg: 25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)