### PR TITLE
Go Heavier: stats page, session stats and session creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import Locations from "./pages/go_heavier/Locations"
 import LocationDetail from "./pages/go_heavier/LocationDetail"
 import Exercises from "./pages/go_heavier/Exercises"
 import ExerciseDetail from "./pages/go_heavier/ExerciseDetail"
+import Sessions from "./pages/go_heavier/Sessions"
+import SessionDetail from "./pages/go_heavier/SessionDetail"
 import Workouts from "./pages/go_heavier/Workouts"
 
 const NavBar: React.FC = () => (
@@ -43,6 +45,8 @@ const App: React.FC = () => {
                         <Route path="/go-heavier/locations/:id" element={<LocationDetail />} />
                         <Route path="/go-heavier/exercises" element={<Exercises />} />
                         <Route path="/go-heavier/exercises/:id" element={<ExerciseDetail />} />
+                        <Route path="/go-heavier/sessions" element={<Sessions />} />
+                        <Route path="/go-heavier/sessions/:id" element={<SessionDetail />} />
                         <Route path="/go-heavier/workouts" element={<Workouts />} />
                         {/* <Route path="/go-heavier/exercises/:locationId" element={<Exercises />} /> */}
                         <Route path="/about" element={<About />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import LocationDetail from "./pages/go_heavier/LocationDetail"
 import Exercises from "./pages/go_heavier/Exercises"
 import ExerciseDetail from "./pages/go_heavier/ExerciseDetail"
 import Sessions from "./pages/go_heavier/Sessions"
+import Stats from "./pages/go_heavier/Stats"
 import SessionDetail from "./pages/go_heavier/SessionDetail"
 import Workouts from "./pages/go_heavier/Workouts"
 
@@ -46,6 +47,7 @@ const App: React.FC = () => {
                         <Route path="/go-heavier/exercises" element={<Exercises />} />
                         <Route path="/go-heavier/exercises/:id" element={<ExerciseDetail />} />
                         <Route path="/go-heavier/sessions" element={<Sessions />} />
+                        <Route path="/go-heavier/stats" element={<Stats />} />
                         <Route path="/go-heavier/sessions/:id" element={<SessionDetail />} />
                         <Route path="/go-heavier/workouts" element={<Workouts />} />
                         {/* <Route path="/go-heavier/exercises/:locationId" element={<Exercises />} /> */}

--- a/src/components/go_heavier/BarChart.css
+++ b/src/components/go_heavier/BarChart.css
@@ -1,0 +1,218 @@
+/* Column chart. One series per chart, so the title carries the identity and
+   there is no legend. Marks stay thin, the grid stays recessive. */
+
+.chart {
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    padding: 24px;
+    margin: 0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.chart-caption {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.chart-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.chart-subtitle {
+    margin: 4px 0 0 0;
+    font-size: 0.8125rem;
+    color: #718096;
+}
+
+.chart-toggle {
+    background: none;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    padding: 4px 12px;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #718096;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.chart-toggle:hover {
+    border-color: #667eea;
+    color: #667eea;
+}
+
+/* Plot */
+.chart-plot {
+    display: flex;
+    gap: 12px;
+    height: 220px;
+}
+
+.chart-scale {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: flex-end;
+    flex-shrink: 0;
+    /* Half a line box, so each tick sits on its gridline. */
+    margin: -0.5em 0;
+}
+
+.chart-tick {
+    font-size: 0.6875rem;
+    color: #a0aec0;
+    line-height: 1;
+}
+
+.chart-area {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+}
+
+.chart-gridline {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: #edf0f4;
+}
+
+.chart-bars {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    /* The surface gap that separates neighbouring columns. */
+    gap: 2px;
+}
+
+.chart-band {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    height: 100%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+}
+
+.chart-bar {
+    position: relative;
+    width: 100%;
+    max-width: 24px;
+    min-height: 2px;
+    background: #667eea;
+    /* Rounded data-end, square where it meets the baseline. */
+    border-radius: 4px 4px 0 0;
+    transition: opacity 0.15s ease;
+}
+
+.chart-band:hover .chart-bar {
+    opacity: 0.75;
+}
+
+/* Only the tallest column is labelled; the axis and tooltip carry the rest. */
+.chart-peak-label {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translate(-50%, -4px);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: #5a6c7d;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+.chart-tooltip {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translate(-50%, -20px);
+    background: #2c3e50;
+    color: white;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    white-space: nowrap;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    pointer-events: none;
+    z-index: 5;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.chart-tooltip-inside {
+    bottom: auto;
+    top: 6px;
+    transform: translate(-50%, 0);
+}
+
+.chart-axis {
+    display: flex;
+    gap: 2px;
+    margin-top: 8px;
+}
+
+.chart-axis-label {
+    flex: 1;
+    min-width: 0;
+    text-align: center;
+    font-size: 0.6875rem;
+    color: #a0aec0;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+/* Table view, so every value is reachable without hovering */
+.chart-table-wrapper {
+    overflow-x: auto;
+}
+
+.chart-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+}
+
+.chart-table th {
+    text-align: left;
+    padding: 8px 12px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: #718096;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.chart-table td {
+    padding: 8px 12px;
+    color: #5a6c7d;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.chart-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+@media (max-width: 767px) {
+    .chart {
+        padding: 16px;
+    }
+
+    .chart-plot {
+        height: 180px;
+    }
+}

--- a/src/components/go_heavier/BarChart.tsx
+++ b/src/components/go_heavier/BarChart.tsx
@@ -1,0 +1,159 @@
+import React from "react"
+
+import "./BarChart.css"
+
+export interface BarChartPoint {
+    label: string
+    value: number
+}
+
+interface Props {
+    title: string
+    subtitle?: string
+    data: BarChartPoint[]
+    formatValue: (value: number) => string
+    // Column axis labels collide once there are many; show every nth.
+    labelEvery?: number
+}
+
+interface State {
+    hovered: number | null
+    showTable: boolean
+}
+
+const TICK_COUNT = 4
+
+export default class BarChart extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props)
+        this.state = {
+            hovered: null,
+            showTable: false
+        }
+    }
+
+    // A round number at or above the tallest bar, so the ticks read cleanly.
+    niceMax = (max: number): number => {
+        if (max <= 0) {
+            return 1
+        }
+
+        const magnitude = Math.pow(10, Math.floor(Math.log10(max)))
+        const steps = [1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10]
+        const step = steps.find(candidate => max <= candidate * magnitude) ?? 10
+
+        return step * magnitude
+    }
+
+    render(): React.ReactNode {
+        const { title, subtitle, data, formatValue, labelEvery = 1 } = this.props
+        const max = this.niceMax(Math.max(...data.map(point => point.value), 0))
+        const peak = data.reduce(
+            (best, point, index) => (point.value > data[best].value ? index : best),
+            0
+        )
+
+        const ticks = Array.from({ length: TICK_COUNT + 1 }, (_, i) => (max / TICK_COUNT) * i)
+
+        return (
+            <figure className="chart">
+                <figcaption className="chart-caption">
+                    <div>
+                        <h4 className="chart-title">{title}</h4>
+                        {subtitle && <p className="chart-subtitle">{subtitle}</p>}
+                    </div>
+                    <button
+                        type="button"
+                        className="chart-toggle"
+                        onClick={() => this.setState({ showTable: !this.state.showTable })}
+                    >
+                        {this.state.showTable ? "Chart" : "Table"}
+                    </button>
+                </figcaption>
+
+                {this.state.showTable ? (
+                    <div className="chart-table-wrapper">
+                        <table className="chart-table">
+                            <thead>
+                                <tr>
+                                    <th>Period</th>
+                                    <th>{title}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {data.map(point => (
+                                    <tr key={point.label}>
+                                        <td>{point.label}</td>
+                                        <td>{formatValue(point.value)}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                ) : (
+                    <>
+                        <div className="chart-plot">
+                            <div className="chart-scale">
+                                {ticks.slice().reverse().map(tick => (
+                                    <span key={tick} className="chart-tick">{formatValue(tick)}</span>
+                                ))}
+                            </div>
+
+                            <div className="chart-area">
+                                {ticks.map(tick => (
+                                    <div
+                                        key={tick}
+                                        className="chart-gridline"
+                                        style={{ bottom: `${(tick / max) * 100}%` }}
+                                    />
+                                ))}
+
+                                <div className="chart-bars">
+                                    {data.map((point, index) => (
+                                        <div
+                                            key={point.label}
+                                            className="chart-band"
+                                            onMouseEnter={() => this.setState({ hovered: index })}
+                                            onMouseLeave={() => this.setState({ hovered: null })}
+                                        >
+                                            <div
+                                                className="chart-bar"
+                                                style={{ height: `${(point.value / max) * 100}%` }}
+                                            >
+                                                {index === peak && point.value > 0 && (
+                                                    <span className="chart-peak-label">
+                                                        {formatValue(point.value)}
+                                                    </span>
+                                                )}
+                                                {this.state.hovered === index && (
+                                                    <div className={
+                                                        // A tall bar has no room above it, so the
+                                                        // tooltip drops inside instead of overflowing.
+                                                        point.value / max > 0.7
+                                                            ? "chart-tooltip chart-tooltip-inside"
+                                                            : "chart-tooltip"
+                                                    }>
+                                                        <strong>{point.label}</strong>
+                                                        <span>{formatValue(point.value)}</span>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="chart-axis">
+                            {data.map((point, index) => (
+                                <span key={point.label} className="chart-axis-label">
+                                    {index % labelEvery === 0 ? point.label : ""}
+                                </span>
+                            ))}
+                        </div>
+                    </>
+                )}
+            </figure>
+        )
+    }
+}

--- a/src/components/go_heavier/NavBar.tsx
+++ b/src/components/go_heavier/NavBar.tsx
@@ -34,6 +34,12 @@ export default function GoHeavierNavBar() {
                         🗓️ Sessions
                     </Link>
                     <Link 
+                        to="/go-heavier/stats" 
+                        className={location.pathname === "/go-heavier/stats" ? "active" : ""}
+                    >
+                        📈 Stats
+                    </Link>
+                    <Link 
                         to="/go-heavier/workouts" 
                         className={location.pathname === "/go-heavier/workouts" ? "active" : ""}
                     >

--- a/src/components/go_heavier/NavBar.tsx
+++ b/src/components/go_heavier/NavBar.tsx
@@ -28,6 +28,12 @@ export default function GoHeavierNavBar() {
                         🏋️ Exercises
                     </Link>
                     <Link 
+                        to="/go-heavier/sessions" 
+                        className={location.pathname === "/go-heavier/sessions" || location.pathname.startsWith("/go-heavier/sessions/") ? "active" : ""}
+                    >
+                        🗓️ Sessions
+                    </Link>
+                    <Link 
                         to="/go-heavier/workouts" 
                         className={location.pathname === "/go-heavier/workouts" ? "active" : ""}
                     >

--- a/src/components/go_heavier/SessionForm.tsx
+++ b/src/components/go_heavier/SessionForm.tsx
@@ -1,0 +1,167 @@
+import React from "react"
+
+import { API_URL } from "../../configs"
+import { SessionSummary } from "./sessions"
+import "./LocationForm.css"
+
+interface Props {
+    onClose: () => void
+    onSuccess: (session: SessionSummary) => void
+}
+
+interface State {
+    formData: {
+        location_id: string
+        workout_time: string
+    }
+    locations: any[]
+    loading: boolean
+    error: string | null
+}
+
+export default class SessionForm extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props)
+
+        // datetime-local wants a local wall-clock value, not an ISO instant.
+        const now = new Date()
+        const pad = (value: number) => String(value).padStart(2, '0')
+        const localDateTime = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+            + `T${pad(now.getHours())}:${pad(now.getMinutes())}`
+
+        this.state = {
+            formData: {
+                location_id: "",
+                workout_time: localDateTime
+            },
+            locations: [],
+            loading: false,
+            error: null
+        }
+    }
+
+    componentDidMount() {
+        this.fetchLocations()
+    }
+
+    fetchLocations = async () => {
+        try {
+            const response = await fetch(`${API_URL}/go-heavier/locations`)
+            if (!response.ok) {
+                throw new Error("Failed to load locations")
+            }
+            const locations = await response.json()
+            this.setState({
+                locations,
+                formData: {
+                    ...this.state.formData,
+                    location_id: locations.length > 0 ? locations[0].id : ""
+                }
+            })
+        } catch (error) {
+            console.error("Error fetching locations:", error)
+            this.setState({ error: "Failed to load locations" })
+        }
+    }
+
+    handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        const { name, value } = e.target
+        this.setState((prevState) => ({
+            formData: { ...prevState.formData, [name]: value }
+        }))
+    }
+
+    handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        this.setState({ error: null })
+
+        const { location_id, workout_time } = this.state.formData
+
+        if (!location_id) {
+            this.setState({ error: "Location is required" })
+            return
+        }
+
+        if (!workout_time) {
+            this.setState({ error: "Time is required" })
+            return
+        }
+
+        this.setState({ loading: true })
+
+        try {
+            const response = await fetch(`${API_URL}/go-heavier/sessions`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    location_id,
+                    // The picker gives local wall-clock time; send the instant it means.
+                    workout_time: new Date(workout_time).toISOString()
+                })
+            })
+
+            if (!response.ok) {
+                throw new Error("Failed to create session")
+            }
+
+            const session = await response.json()
+            this.props.onSuccess(session)
+        } catch (err) {
+            this.setState({ error: (err as Error).message, loading: false })
+        }
+    }
+
+    render(): React.ReactNode {
+        return (
+            <div className="popup-overlay" onClick={this.props.onClose}>
+                <div className="popup-form" onClick={(e) => e.stopPropagation()}>
+                    <button className="close-button" onClick={this.props.onClose}>
+                        ✖
+                    </button>
+                    <h2>Add New Session</h2>
+                    <form onSubmit={this.handleSubmit}>
+                        <label>
+                            Location: <span className="required">*</span>
+                            <select
+                                name="location_id"
+                                value={this.state.formData.location_id}
+                                onChange={this.handleChange}
+                                required
+                            >
+                                <option value="">Select location...</option>
+                                {this.state.locations.map(location => (
+                                    <option key={location.id} value={location.id}>
+                                        {location.name}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+
+                        <label>
+                            Time: <span className="required">*</span>
+                            <input
+                                type="datetime-local"
+                                name="workout_time"
+                                value={this.state.formData.workout_time}
+                                onChange={this.handleChange}
+                                required
+                            />
+                        </label>
+
+                        {this.state.error && <p className="error-message">{this.state.error}</p>}
+                        <div className="form-actions">
+                            <button type="submit" disabled={this.state.loading}>
+                                {this.state.loading ? "Creating..." : "Create Session"}
+                            </button>
+                            <button type="button" onClick={this.props.onClose}>
+                                Cancel
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        )
+    }
+}

--- a/src/components/go_heavier/WorkoutForm.tsx
+++ b/src/components/go_heavier/WorkoutForm.tsx
@@ -99,29 +99,61 @@ export default class WorkoutForm extends React.Component<Props, State> {
     }
 
     validateForm = (): boolean => {
-        const { session_id, exercise_id, index, repetitions, weight_kg } = this.state.formData
+        const {
+            session_id,
+            exercise_id,
+            index,
+            repetitions,
+            weight_kg,
+            bar_weight_kg,
+            supplementary_weight_kg
+        } = this.state.formData
 
         if (!session_id || !exercise_id) {
             this.setState({ error: "Session and Exercise are required" })
             return false
         }
 
-        if (index < 1) {
-            this.setState({ error: "Set number must be at least 1" })
+        if (index < 1 || index > 99) {
+            this.setState({ error: "Set number must be between 1 and 99" })
             return false
         }
 
-        if (repetitions < 1) {
-            this.setState({ error: "Repetitions must be at least 1" })
+        if (repetitions < 1 || repetitions > 99) {
+            this.setState({ error: "Repetitions must be between 1 and 99" })
             return false
         }
 
-        if (weight_kg < 0) {
-            this.setState({ error: "Weight cannot be negative" })
+        // Negative weight is valid: an assisted machine takes weight off the lifter.
+        if (weight_kg <= -1000 || weight_kg >= 1000) {
+            this.setState({ error: "Weight must be between -999 and 999 kg" })
+            return false
+        }
+
+        if (bar_weight_kg < 0 || bar_weight_kg >= 100) {
+            this.setState({ error: "Bar weight must be between 0 and 99 kg" })
+            return false
+        }
+
+        if (supplementary_weight_kg <= -100 || supplementary_weight_kg >= 100) {
+            this.setState({ error: "Supplementary weight must be between -99 and 99 kg" })
             return false
         }
 
         return true
+    }
+
+    // The API takes null rather than zero for the optional weights, and rejects a
+    // bar weight of zero outright.
+    buildPayload = () => {
+        const { bar_weight_kg, supplementary_weight_kg, notes, ...rest } = this.state.formData
+
+        return {
+            ...rest,
+            bar_weight_kg: bar_weight_kg > 0 ? bar_weight_kg : null,
+            supplementary_weight_kg: supplementary_weight_kg !== 0 ? supplementary_weight_kg : null,
+            notes: notes.trim() ? notes.trim() : null
+        }
     }
 
     handleSubmit = async (e: React.FormEvent) => {
@@ -140,7 +172,7 @@ export default class WorkoutForm extends React.Component<Props, State> {
                 headers: {
                     "Content-Type": "application/json"
                 },
-                body: JSON.stringify({ workouts: [this.state.formData] })
+                body: JSON.stringify({ workouts: [this.buildPayload()] })
             })
 
             if (!response.ok) {

--- a/src/components/go_heavier/WorkoutForm.tsx
+++ b/src/components/go_heavier/WorkoutForm.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { API_URL } from "../../configs"
+import { SessionSummary, fetchAllSessions } from "./sessions"
 import "./ExerciseForm.css"
 
 interface Props {
@@ -9,10 +10,8 @@ interface Props {
 
 interface State {
     formData: {
-        location_id: string
+        session_id: string
         exercise_id: string
-        exercise_index: number
-        workout_time: string
         index: number
         repetitions: number
         weight_kg: number
@@ -22,29 +21,18 @@ interface State {
     }
     loading: boolean
     error: string | null
-    locations: any[]
+    sessions: SessionSummary[]
     exercises: any[]
 }
 
 export default class WorkoutForm extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props)
-        
-        // Get current date and time in local timezone
-        const now = new Date()
-        const year = now.getFullYear()
-        const month = String(now.getMonth() + 1).padStart(2, '0')
-        const day = String(now.getDate()).padStart(2, '0')
-        const hours = String(now.getHours()).padStart(2, '0')
-        const minutes = String(now.getMinutes()).padStart(2, '0')
-        const localDateTime = `${year}-${month}-${day}T${hours}:${minutes}`
-        
+
         this.state = {
             formData: {
-                location_id: "",
+                session_id: "",
                 exercise_id: "",
-                exercise_index: 0,
-                workout_time: localDateTime,
                 index: 1,
                 repetitions: 10,
                 weight_kg: 0,
@@ -54,38 +42,49 @@ export default class WorkoutForm extends React.Component<Props, State> {
             },
             loading: false,
             error: null,
-            locations: [],
+            sessions: [],
             exercises: []
         }
     }
 
     componentDidMount() {
-        this.fetchLocationsAndExercises()
+        this.fetchSessionsAndExercises()
     }
 
-    fetchLocationsAndExercises = async () => {
+    // Sessions are read only on the API, so a new set has to join an existing one.
+    fetchSessionsAndExercises = async () => {
         try {
-            const [locationsRes, exercisesRes] = await Promise.all([
-                fetch(`${API_URL}/go-heavier/locations`),
+            const [sessions, exercisesRes] = await Promise.all([
+                fetchAllSessions(),
                 fetch(`${API_URL}/go-heavier/exercises`)
             ])
-            
-            const locations = await locationsRes.json()
+
             const exercises = await exercisesRes.json()
-            
+
             this.setState({ 
-                locations, 
+                sessions, 
                 exercises,
                 formData: {
                     ...this.state.formData,
-                    location_id: locations.length > 0 ? locations[0].id : "",
+                    session_id: sessions.length > 0 ? sessions[0].id : "",
                     exercise_id: exercises.length > 0 ? exercises[0].id : ""
                 }
             })
         } catch (error) {
             console.error("Error fetching data:", error)
-            this.setState({ error: "Failed to load locations and exercises" })
+            this.setState({ error: "Failed to load sessions and exercises" })
         }
+    }
+
+    formatSessionOption = (session: SessionSummary): string => {
+        const when = new Date(session.workout_time).toLocaleString("en-US", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit"
+        })
+        return `${when} — ${session.location}`
     }
 
     handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
@@ -100,15 +99,10 @@ export default class WorkoutForm extends React.Component<Props, State> {
     }
 
     validateForm = (): boolean => {
-        const { location_id, exercise_id, workout_time, index, repetitions, weight_kg } = this.state.formData
+        const { session_id, exercise_id, index, repetitions, weight_kg } = this.state.formData
 
-        if (!location_id || !exercise_id) {
-            this.setState({ error: "Location and Exercise are required" })
-            return false
-        }
-
-        if (!workout_time) {
-            this.setState({ error: "Workout time is required" })
+        if (!session_id || !exercise_id) {
+            this.setState({ error: "Session and Exercise are required" })
             return false
         }
 
@@ -146,7 +140,7 @@ export default class WorkoutForm extends React.Component<Props, State> {
                 headers: {
                     "Content-Type": "application/json"
                 },
-                body: JSON.stringify(this.state.formData)
+                body: JSON.stringify({ workouts: [this.state.formData] })
             })
 
             if (!response.ok) {
@@ -170,17 +164,17 @@ export default class WorkoutForm extends React.Component<Props, State> {
                     <h2>Add New Workout</h2>
                     <form onSubmit={this.handleSubmit}>
                         <label>
-                            Location: <span className="required">*</span>
+                            Session: <span className="required">*</span>
                             <select
-                                name="location_id"
-                                value={this.state.formData.location_id}
+                                name="session_id"
+                                value={this.state.formData.session_id}
                                 onChange={this.handleChange}
                                 required
                             >
-                                <option value="">Select location...</option>
-                                {this.state.locations.map(location => (
-                                    <option key={location.id} value={location.id}>
-                                        {location.name}
+                                <option value="">Select session...</option>
+                                {this.state.sessions.map(session => (
+                                    <option key={session.id} value={session.id}>
+                                        {this.formatSessionOption(session)}
                                     </option>
                                 ))}
                             </select>
@@ -201,17 +195,6 @@ export default class WorkoutForm extends React.Component<Props, State> {
                                     </option>
                                 ))}
                             </select>
-                        </label>
-
-                        <label>
-                            Workout Time: <span className="required">*</span>
-                            <input
-                                type="datetime-local"
-                                name="workout_time"
-                                value={this.state.formData.workout_time}
-                                onChange={this.handleChange}
-                                required
-                            />
                         </label>
 
                         <label>
@@ -271,17 +254,6 @@ export default class WorkoutForm extends React.Component<Props, State> {
                                 value={this.state.formData.supplementary_weight_kg}
                                 onChange={this.handleChange}
                                 step="0.1"
-                                min="0"
-                            />
-                        </label>
-
-                        <label>
-                            Exercise Index:
-                            <input
-                                type="number"
-                                name="exercise_index"
-                                value={this.state.formData.exercise_index}
-                                onChange={this.handleChange}
                                 min="0"
                             />
                         </label>

--- a/src/components/go_heavier/sessions.ts
+++ b/src/components/go_heavier/sessions.ts
@@ -11,10 +11,48 @@ export interface SessionSummary {
     exercises: number
     repetitions: number
     volume_kg: number
-    heaviest_weight_kg: number
+    heaviest_weight_kg: number | null
+}
+
+export interface SessionHighlight {
+    id: string
+    workout_time: string
+    location: string
+    sets: number
+    volume_kg: number
+}
+
+export interface WeekdayStats {
+    weekday: string
+    sessions: number
+    sets: number
+    volume_kg: number
+}
+
+export interface SessionStats {
+    sessions: number
+    first_session: string | null
+    last_session: string | null
+    average_sets_per_session: number
+    average_exercises_per_session: number
+    average_repetitions_per_session: number
+    average_volume_kg_per_session: number
+    average_days_between_sessions: number | null
+    longest_gap_days: number | null
+    busiest_session: SessionHighlight | null
+    heaviest_session: SessionHighlight | null
+    by_weekday?: WeekdayStats[]
 }
 
 export const SESSIONS_CACHE_KEY = "go-heavier-sessions"
+
+export async function fetchSessionStats(): Promise<SessionStats> {
+    const response = await fetch(`${API_URL}/go-heavier/sessions/stats`)
+    if (!response.ok) {
+        throw new Error("Failed to load session stats")
+    }
+    return response.json()
+}
 
 // Guard on the page walk so a misbehaving endpoint can't loop forever.
 const MAX_SESSION_PAGES = 500

--- a/src/components/go_heavier/sessions.ts
+++ b/src/components/go_heavier/sessions.ts
@@ -1,0 +1,72 @@
+import { API_URL } from "../../configs"
+
+// A session is one visit to a gym. Sets belong to a session, and the session
+// carries the location and the time — a set no longer carries either itself.
+export interface SessionSummary {
+    id: string
+    workout_time: string
+    location_id: string
+    location: string
+    sets: number
+    exercises: number
+    repetitions: number
+    volume_kg: number
+    heaviest_weight_kg: number
+}
+
+export const SESSIONS_CACHE_KEY = "go-heavier-sessions"
+
+// Guard on the page walk so a misbehaving endpoint can't loop forever.
+const MAX_SESSION_PAGES = 500
+
+// StrictMode mounts a component twice in development, and several pages ask for
+// the full list at once. Concurrent callers share one walk rather than each
+// starting their own; the entry clears as soon as it settles.
+let inFlight: Promise<SessionSummary[]> | null = null
+
+export function fetchAllSessions(exerciseId?: string): Promise<SessionSummary[]> {
+    if (exerciseId) {
+        return walkSessions(exerciseId)
+    }
+
+    if (!inFlight) {
+        inFlight = walkSessions().finally(() => {
+            inFlight = null
+        })
+    }
+
+    return inFlight
+}
+
+// The endpoint pages its results, newest first, so walk until one comes back empty.
+async function walkSessions(exerciseId?: string): Promise<SessionSummary[]> {
+    const all: SessionSummary[] = []
+
+    for (let page = 1; page <= MAX_SESSION_PAGES; page++) {
+        const params = new URLSearchParams({ page: String(page) })
+        if (exerciseId) {
+            params.set("exercise_id", exerciseId)
+        }
+
+        const response = await fetch(`${API_URL}/go-heavier/sessions?${params}`)
+        if (!response.ok) {
+            throw new Error("Failed to load sessions")
+        }
+
+        const pageSessions: SessionSummary[] = await response.json()
+        if (pageSessions.length === 0) {
+            break
+        }
+        all.push(...pageSessions)
+    }
+
+    return all
+}
+
+export function indexSessions(sessions: SessionSummary[]): Record<string, SessionSummary> {
+    const byId: Record<string, SessionSummary> = {}
+    sessions.forEach(session => {
+        byId[session.id] = session
+    })
+    return byId
+}

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,7 +1,9 @@
 export const API_URL = process.env.API_URL || "http://localhost:8000"
 
-// Every workout page the app has fetched, written by the workouts page.
-export const WORKOUTS_CACHE_KEY = "go-heavier-workouts"
+// Every workout page the app has fetched, written by the workouts page. The
+// suffix is bumped whenever the workout shape changes so a stale cache from an
+// older schema is ignored rather than rendered.
+export const WORKOUTS_CACHE_KEY = "go-heavier-workouts-v2"
 
 export function countryCodeToEmoji(countryCode: string): string {
     const codePoints = countryCode

--- a/src/pages/GoHeavier.tsx
+++ b/src/pages/GoHeavier.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import { Link } from "react-router-dom"
 
-import { API_URL, WORKOUTS_CACHE_KEY } from "../configs"
+import { API_URL } from "../configs"
+import { fetchAllSessions } from "../components/go_heavier/sessions"
 import GoHeavierNavBar from "../components/go_heavier/NavBar"
 import "./GoHeavier.css"
 
@@ -10,6 +11,7 @@ interface State {
     isRefreshing: boolean
     locationCount?: number
     exerciseCount?: number
+    sessionCount?: number
     workoutCount?: number
 }
 
@@ -21,6 +23,7 @@ export default class GoHeavier extends React.Component<{}, State> {
             isRefreshing: false,
             locationCount: undefined,
             exerciseCount: undefined,
+            sessionCount: undefined,
             workoutCount: undefined
         }
     }
@@ -33,11 +36,8 @@ export default class GoHeavier extends React.Component<{}, State> {
 
         this.setState({ isRefreshing: true })
         try {
-            // Workouts are paged, so the count comes from what the workouts page cached.
-            const cachedWorkouts = localStorage.getItem(WORKOUTS_CACHE_KEY)
-            const workoutCount = cachedWorkouts ? JSON.parse(cachedWorkouts).length : undefined
-
-            const [locationsRes, exercisesRes] = await Promise.all([
+            const [sessions, locationsRes, exercisesRes] = await Promise.all([
+                fetchAllSessions(),
                 fetch(`${API_URL}/go-heavier/locations`),
                 fetch(`${API_URL}/go-heavier/exercises`)
             ])
@@ -45,12 +45,16 @@ export default class GoHeavier extends React.Component<{}, State> {
             const locations = await locationsRes.json()
             const exercises = await exercisesRes.json()
 
+            // Every set belongs to a session, so the sessions carry the set total.
+            const workoutCount = sessions.reduce((total, session) => total + session.sets, 0)
+
             await waitOut()
             this.setState({
                 loaded: true,
                 isRefreshing: false,
                 locationCount: locations.length,
                 exerciseCount: exercises.length,
+                sessionCount: sessions.length,
                 workoutCount: workoutCount
             })
         } catch (error) {
@@ -135,6 +139,14 @@ export default class GoHeavier extends React.Component<{}, State> {
                                         <div className="stat-value">{this.state.exerciseCount ?? '...'}</div>
                                         <div className="stat-label">Exercises</div>
                                         <p className="stat-caption">Movements in your library</p>
+                                    </div>
+                                </Link>
+                                <Link to="/go-heavier/sessions" className="stat-card">
+                                    <div className="stat-icon">🗓️</div>
+                                    <div className="stat-content">
+                                        <div className="stat-value">{this.state.sessionCount ?? '...'}</div>
+                                        <div className="stat-label">Sessions</div>
+                                        <p className="stat-caption">Visits to the gym</p>
                                     </div>
                                 </Link>
                                 <Link to="/go-heavier/workouts" className="stat-card">

--- a/src/pages/go_heavier/ExerciseDetail.tsx
+++ b/src/pages/go_heavier/ExerciseDetail.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
-import { API_URL, WORKOUTS_CACHE_KEY, formatNotes } from "../../configs"
+import { API_URL, formatNotes } from "../../configs"
+import { SessionSummary, fetchAllSessions, indexSessions } from "../../components/go_heavier/sessions"
 import "../../components/go_heavier/Stats.css"
 import "./ExerciseDetail.css"
 import "../go_heavier/Exercises.css"
@@ -25,15 +26,14 @@ const MAX_WORKOUT_PAGES = 500
 
 interface WorkoutSet {
     id: string
-    location_id: string
+    session_id: string
     exercise_id: string
-    workout_time: string
     index: number
     repetitions: number
     weight_kg: number
-    bar_weight_kg: number
-    supplementary_weight_kg: number
-    notes: string
+    bar_weight_kg: number | null
+    supplementary_weight_kg: number | null
+    notes: string | null
 }
 
 interface TopLocation {
@@ -69,7 +69,8 @@ interface State {
     exerciseSets: WorkoutSet[] | null
     setsLoading: boolean
     setsError: string | null
-    locationNames: Record<string, string>
+    sessions: SessionSummary[]
+    sessionsById: Record<string, SessionSummary>
     loading: boolean
     error: string | null
     isRefreshing: boolean
@@ -99,7 +100,8 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
             exerciseSets: null,
             setsLoading: true,
             setsError: null,
-            locationNames: {},
+            sessions: [],
+            sessionsById: {},
             loading: true,
             error: null,
             isRefreshing: false,
@@ -123,70 +125,51 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
         this.fetchExercise()
         this.fetchStats()
         this.fetchExerciseSets()
-        this.fetchLocationNames()
     }
 
-    fetchLocationNames = async () => {
-        try {
-            const response = await fetch(`${API_URL}/go-heavier/locations`)
-            const locations = await response.json()
-            const locationNames: Record<string, string> = {}
-            locations.forEach((location: { id: string; name: string }) => {
-                locationNames[location.id] = location.name
-            })
-            this.setState({ locationNames })
-        } catch (error) {
-            console.error("Error fetching locations:", error)
-        }
-    }
-
-    // Every set of this exercise, needed for the latest session and the best set.
-    // The workouts endpoint's exercise_id filter currently returns a 500, so the
-    // whole list is matched here. Swap to ?exercise_id= once the API is fixed.
-    fetchExerciseSets = async (useCache: boolean = true) => {
+    // Sets for this exercise, plus the sessions they belong to — a set carries
+    // neither a time nor a location any more, the session does.
+    fetchExerciseSets = async () => {
         this.setState({ setsLoading: true, setsError: null })
         try {
-            // The workouts page caches every page it fetched, so arriving from there
-            // costs nothing. Refreshing always goes back to the API.
-            const cached = useCache ? localStorage.getItem(WORKOUTS_CACHE_KEY) : null
-            const workouts: WorkoutSet[] = cached ? JSON.parse(cached) : await this.fetchAllWorkouts()
+            const [exerciseSets, sessions] = await Promise.all([
+                this.fetchAllSets(),
+                fetchAllSessions(this.props.id)
+            ])
 
-            const exerciseSets = workouts.filter(workout => workout.exercise_id === this.props.id)
-            this.setState({ exerciseSets, setsLoading: false })
+            this.setState({
+                exerciseSets,
+                sessions,
+                sessionsById: indexSessions(sessions),
+                setsLoading: false
+            })
         } catch (error) {
             console.error("Error fetching workouts for this exercise:", error)
             this.setState({ setsError: (error as Error).message, setsLoading: false })
         }
     }
 
-    fetchAllWorkouts = async (): Promise<WorkoutSet[]> => {
-        const workouts: WorkoutSet[] = []
-        const batchSize = 4
-        let page = 1
-        let exhausted = false
+    fetchAllSets = async (): Promise<WorkoutSet[]> => {
+        const sets: WorkoutSet[] = []
 
-        while (!exhausted && page <= MAX_WORKOUT_PAGES) {
-            const firstPage = page
-            const pageNumbers = Array.from({ length: batchSize }, (_, offset) => firstPage + offset)
-            const responses = await Promise.all(
-                pageNumbers.map(pageNumber => fetch(`${API_URL}/go-heavier/workouts?page=${pageNumber}`))
-            )
-
-            for (const response of responses) {
-                if (!response.ok) {
-                    throw new Error("Failed to load workouts")
-                }
-                const pageWorkouts: WorkoutSet[] = await response.json()
-                if (pageWorkouts.length === 0) {
-                    exhausted = true
-                } else {
-                    workouts.push(...pageWorkouts)
-                }
+        for (let page = 1; page <= MAX_WORKOUT_PAGES; page++) {
+            const params = new URLSearchParams({
+                exercise_id: this.props.id,
+                page: String(page)
+            })
+            const response = await fetch(`${API_URL}/go-heavier/workouts?${params}`)
+            if (!response.ok) {
+                throw new Error("Failed to load workouts")
             }
-            page += batchSize
+
+            const pageSets: WorkoutSet[] = await response.json()
+            if (pageSets.length === 0) {
+                break
+            }
+            sets.push(...pageSets)
         }
 
-        return workouts
+        return sets
     }
 
 
@@ -235,7 +218,7 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
     handleRefresh = async () => {
         this.setState({ isRefreshing: true })
         this.fetchStats()
-        this.fetchExerciseSets(false)
+        this.fetchExerciseSets()
         try {
             const response = await fetch(`${API_URL}/go-heavier/exercises/${this.props.id}`)
             if (!response.ok) {
@@ -379,22 +362,28 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
         })
     }
 
-    // Every set from the most recent day this exercise was performed.
+    // The most recent session this exercise was performed in.
+    getLatestSession = (): SessionSummary | null => {
+        const sessions = this.state.sessions
+        if (sessions.length === 0) {
+            return null
+        }
+
+        return sessions.reduce((latest, session) =>
+            new Date(session.workout_time) > new Date(latest.workout_time) ? session : latest
+        )
+    }
+
+    // Every set of this exercise logged in that session.
     getLatestSets = (): WorkoutSet[] => {
-        const sets = this.state.exerciseSets ?? []
-        if (sets.length === 0) {
+        const latest = this.getLatestSession()
+        if (!latest) {
             return []
         }
 
-        const latest = new Date(Math.max(...sets.map(set => new Date(set.workout_time).getTime())))
-        const onLatestDay = (value: string) => {
-            const performed = new Date(value)
-            return performed.getFullYear() === latest.getFullYear()
-                && performed.getMonth() === latest.getMonth()
-                && performed.getDate() === latest.getDate()
-        }
-
-        return sets.filter(set => onLatestDay(set.workout_time)).sort((a, b) => a.index - b.index)
+        return (this.state.exerciseSets ?? [])
+            .filter(set => set.session_id === latest.id)
+            .sort((a, b) => a.index - b.index)
     }
 
     // Heaviest set, the same measure as the "Heaviest lift" stat. Ties go to the
@@ -412,12 +401,17 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
             if (set.repetitions !== best.repetitions) {
                 return set.repetitions > best.repetitions ? set : best
             }
-            return new Date(set.workout_time) > new Date(best.workout_time) ? set : best
+            const setTime = this.state.sessionsById[set.session_id]?.workout_time
+            const bestTime = this.state.sessionsById[best.session_id]?.workout_time
+            if (!setTime || !bestTime) {
+                return best
+            }
+            return new Date(setTime) > new Date(bestTime) ? set : best
         })
     }
 
-    formatSessionDate = (value: string): string =>
-        new Date(value).toLocaleDateString("en-US", {
+    formatSessionDate = (value?: string): string =>
+        !value ? "\u2014" : new Date(value).toLocaleDateString("en-US", {
             weekday: "long",
             year: "numeric",
             month: "long",
@@ -459,8 +453,10 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
     }
 
     render(): React.ReactNode {
+        const latestSession = this.getLatestSession()
         const latestSets = this.getLatestSets()
         const bestSet = this.getBestSet()
+        const bestSetSession = bestSet ? this.state.sessionsById[bestSet.session_id] : undefined
 
         if (this.state.showDeleteConfirm) {
             return (
@@ -738,19 +734,26 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
                                     ) : (
                                         <div className="detail-card">
                                             <div className="latest-workout-meta">
-                                                <span className="latest-workout-date">
-                                                    {this.formatSessionDate(latestSets[0].workout_time)}
-                                                </span>
-                                                {this.state.locationNames[latestSets[0].location_id] && (
+                                                <a
+                                                    className="latest-workout-date"
+                                                    href={`/go-heavier/sessions/${latestSets[0].session_id}`}
+                                                    onClick={(e) => {
+                                                        e.preventDefault()
+                                                        this.props.navigate(`/go-heavier/sessions/${latestSets[0].session_id}`)
+                                                    }}
+                                                >
+                                                    {this.formatSessionDate(latestSession?.workout_time)}
+                                                </a>
+                                                {latestSession && (
                                                     <a
                                                         className="latest-workout-location"
-                                                        href={`/go-heavier/locations/${latestSets[0].location_id}`}
+                                                        href={`/go-heavier/locations/${latestSession.location_id}`}
                                                         onClick={(e) => {
                                                             e.preventDefault()
-                                                            this.props.navigate(`/go-heavier/locations/${latestSets[0].location_id}`)
+                                                            this.props.navigate(`/go-heavier/locations/${latestSession.location_id}`)
                                                         }}
                                                     >
-                                                        📍 {this.state.locationNames[latestSets[0].location_id]}
+                                                        📍 {latestSession.location}
                                                     </a>
                                                 )}
                                                 <span className="latest-workout-count">
@@ -823,17 +826,26 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
                                                 <span className="best-set-reps">× {bestSet.repetitions} reps</span>
                                             </div>
                                             <div className="best-set-meta">
-                                                <span>{this.formatSessionDate(bestSet.workout_time)}</span>
-                                                {this.state.locationNames[bestSet.location_id] && (
+                                                <a
+                                                    className="latest-workout-location"
+                                                    href={`/go-heavier/sessions/${bestSet.session_id}`}
+                                                    onClick={(e) => {
+                                                        e.preventDefault()
+                                                        this.props.navigate(`/go-heavier/sessions/${bestSet.session_id}`)
+                                                    }}
+                                                >
+                                                    {this.formatSessionDate(bestSetSession?.workout_time)}
+                                                </a>
+                                                {bestSetSession && (
                                                     <a
                                                         className="latest-workout-location"
-                                                        href={`/go-heavier/locations/${bestSet.location_id}`}
+                                                        href={`/go-heavier/locations/${bestSetSession.location_id}`}
                                                         onClick={(e) => {
                                                             e.preventDefault()
-                                                            this.props.navigate(`/go-heavier/locations/${bestSet.location_id}`)
+                                                            this.props.navigate(`/go-heavier/locations/${bestSetSession.location_id}`)
                                                         }}
                                                     >
-                                                        📍 {this.state.locationNames[bestSet.location_id]}
+                                                        📍 {bestSetSession.location}
                                                     </a>
                                                 )}
                                                 <span>Set {bestSet.index}</span>

--- a/src/pages/go_heavier/ExerciseDetail.tsx
+++ b/src/pages/go_heavier/ExerciseDetail.tsx
@@ -631,7 +631,12 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
                                     <button className="edit-action-button" onClick={this.handleEdit}>
                                         ✏️ Edit Exercise
                                     </button>
-                                    <button className="delete-action-button" onClick={this.handleDelete}>
+                                    <button
+                                        className="delete-action-button"
+                                        onClick={this.handleDelete}
+                                        disabled
+                                        title="Deleting is restricted to admins"
+                                    >
                                         🗑️ Delete Exercise
                                     </button>
                                 </div>

--- a/src/pages/go_heavier/LocationDetail.css
+++ b/src/pages/go_heavier/LocationDetail.css
@@ -160,10 +160,20 @@
     color: white;
 }
 
-.delete-action-button:hover {
+.delete-action-button:hover:not(:disabled) {
     background: #dc2626;
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(239, 68, 68, 0.3);
+}
+
+/* Deleting is admin only, and admin is not defined yet */
+.edit-action-button:disabled,
+.delete-action-button:disabled {
+    background: #e2e8f0;
+    color: #94a3b8;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
 }
 
 /* Custom confirmation dialog */

--- a/src/pages/go_heavier/LocationDetail.tsx
+++ b/src/pages/go_heavier/LocationDetail.tsx
@@ -542,7 +542,12 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
                                     <button className="edit-action-button" onClick={this.handleEdit}>
                                         ✏️ Edit Location
                                     </button>
-                                    <button className="delete-action-button" onClick={this.handleDelete}>
+                                    <button
+                                        className="delete-action-button"
+                                        onClick={this.handleDelete}
+                                        disabled
+                                        title="Deleting is restricted to admins"
+                                    >
                                         🗑️ Delete Location
                                     </button>
                                 </div>

--- a/src/pages/go_heavier/SessionDetail.tsx
+++ b/src/pages/go_heavier/SessionDetail.tsx
@@ -1,0 +1,310 @@
+import React from "react"
+import { useNavigate, useParams } from "react-router-dom"
+
+import GoHeavierNavBar from "../../components/go_heavier/NavBar"
+import { API_URL, formatNotes } from "../../configs"
+import "../GoHeavier.css"
+import "../../components/go_heavier/Stats.css"
+import "./Sessions.css"
+import "./LocationDetail.css"
+
+interface SessionExerciseStats {
+    exercise_id: string
+    name: string
+    sets: number
+    repetitions: number
+    volume_kg: number
+    heaviest_weight_kg: number
+}
+
+interface SessionData {
+    id: string
+    workout_time: string
+    location_id: string
+    location: string
+    sets: number
+    exercises: number
+    repetitions: number
+    volume_kg: number
+    heaviest_weight_kg: number
+    by_exercise?: SessionExerciseStats[]
+}
+
+interface WorkoutSet {
+    id: string
+    session_id: string
+    exercise_id: string
+    index: number
+    repetitions: number
+    weight_kg: number
+    bar_weight_kg: number | null
+    supplementary_weight_kg: number | null
+    notes: string | null
+}
+
+interface Props {
+    id: string
+    navigate: (path: string) => void
+}
+
+interface State {
+    session: SessionData | null
+    loading: boolean
+    error: string | null
+    isRefreshing: boolean
+    sets: WorkoutSet[] | null
+    setsLoading: boolean
+    setsError: string | null
+}
+
+class SessionDetailClass extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props)
+        this.state = {
+            session: null,
+            loading: true,
+            error: null,
+            isRefreshing: false,
+            sets: null,
+            setsLoading: true,
+            setsError: null
+        }
+    }
+
+    componentDidMount() {
+        this.fetchSession()
+        this.fetchSets()
+    }
+
+    fetchSession = async () => {
+        this.setState({ loading: true, error: null })
+        try {
+            const response = await fetch(`${API_URL}/go-heavier/sessions/${this.props.id}`)
+            if (!response.ok) {
+                throw new Error("Session not found")
+            }
+            const session = await response.json()
+            this.setState({ session, loading: false })
+        } catch (error) {
+            console.error("Error fetching session:", error)
+            this.setState({ error: (error as Error).message, loading: false })
+        }
+    }
+
+    fetchSets = async () => {
+        this.setState({ setsLoading: true, setsError: null })
+        try {
+            const response = await fetch(`${API_URL}/go-heavier/workouts?session_id=${this.props.id}`)
+            if (!response.ok) {
+                throw new Error("Failed to load the sets in this session")
+            }
+            const sets: WorkoutSet[] = await response.json()
+            this.setState({ sets, setsLoading: false })
+        } catch (error) {
+            console.error("Error fetching sets:", error)
+            this.setState({ setsError: (error as Error).message, setsLoading: false })
+        }
+    }
+
+    handleRefresh = () => {
+        this.setState({ isRefreshing: true })
+        Promise.all([this.fetchSession(), this.fetchSets()]).finally(() => {
+            this.setState({ isRefreshing: false })
+        })
+    }
+
+    handleBack = () => {
+        this.props.navigate("/go-heavier/sessions")
+    }
+
+    formatCount = (value: number): string => value.toLocaleString()
+
+    formatWeight = (value: number | null): string =>
+        value === null || value === undefined ? "—" : `${Math.round(value).toLocaleString()} kg`
+
+    formatSessionDate = (value: string): string =>
+        new Date(value).toLocaleDateString("en-US", {
+            weekday: "long",
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit"
+        })
+
+    // The sets come back in exercise order; group them so each exercise reads as a block.
+    groupSetsByExercise = (): Array<{ exercise: SessionExerciseStats; sets: WorkoutSet[] }> => {
+        const byExercise = this.state.session?.by_exercise ?? []
+        const sets = this.state.sets ?? []
+
+        return byExercise.map(exercise => ({
+            exercise,
+            sets: sets
+                .filter(set => set.exercise_id === exercise.exercise_id)
+                .sort((a, b) => a.index - b.index)
+        }))
+    }
+
+    render(): React.ReactNode {
+        const session = this.state.session
+        const grouped = this.groupSetsByExercise()
+
+        return (
+            <div className="center-container-grid">
+                <GoHeavierNavBar />
+                <div className="page-container">
+                    <button className="back-button" onClick={this.handleBack}>
+                        ← Back to Sessions
+                    </button>
+
+                    {!this.state.loading && !this.state.error && (
+                        <button
+                            onClick={this.handleRefresh}
+                            className={`refresh-arrow-button ${this.state.isRefreshing ? 'spinning' : ''}`}
+                            title="Refresh"
+                            disabled={this.state.isRefreshing}
+                        >
+                            ↻
+                        </button>
+                    )}
+
+                    {this.state.loading && (
+                        <div className="loading-spinner">
+                            <div className="spinner"></div>
+                        </div>
+                    )}
+
+                    {this.state.error && (
+                        <div className="error-container">
+                            <h2>Error</h2>
+                            <p className="error-message">{this.state.error}</p>
+                            <button onClick={this.handleBack}>Go Back</button>
+                        </div>
+                    )}
+
+                    {session && (
+                        <div className={`location-detail-container ${this.state.isRefreshing ? 'refreshing' : ''}`}>
+                            <div className="location-detail-header">
+                                <h1>{this.formatSessionDate(session.workout_time)}</h1>
+                                <p className="location-detail-description">
+                                    <button
+                                        className="session-location-link"
+                                        onClick={() => this.props.navigate(`/go-heavier/locations/${session.location_id}`)}
+                                    >
+                                        📍 {session.location}
+                                    </button>
+                                </p>
+                            </div>
+
+                            <div className="detail-section stats-section">
+                                <h3>📊 Session Totals</h3>
+                                <div className="stats-grid">
+                                    <div className="stat-tile">
+                                        <div className="stat-tile-value">{session.exercises}</div>
+                                        <div className="stat-tile-label">Exercises</div>
+                                    </div>
+                                    <div className="stat-tile">
+                                        <div className="stat-tile-value">{session.sets}</div>
+                                        <div className="stat-tile-label">Sets</div>
+                                    </div>
+                                    <div className="stat-tile">
+                                        <div className="stat-tile-value">{this.formatCount(session.repetitions)}</div>
+                                        <div className="stat-tile-label">Reps</div>
+                                    </div>
+                                    <div className="stat-tile">
+                                        <div className="stat-tile-value">{this.formatWeight(session.volume_kg)}</div>
+                                        <div className="stat-tile-label">Volume</div>
+                                    </div>
+                                    <div className="stat-tile">
+                                        <div className="stat-tile-value">{this.formatWeight(session.heaviest_weight_kg)}</div>
+                                        <div className="stat-tile-label">Heaviest</div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="detail-section stats-section">
+                                <h3>🏋️ Exercises</h3>
+
+                                {this.state.setsLoading && (
+                                    <div className="detail-card">
+                                        <p>Loading sets...</p>
+                                    </div>
+                                )}
+
+                                {this.state.setsError && (
+                                    <div className="detail-card">
+                                        <p className="error-message">{this.state.setsError}</p>
+                                    </div>
+                                )}
+
+                                {!this.state.setsLoading && !this.state.setsError && grouped.length === 0 && (
+                                    <div className="detail-card">
+                                        <p>No sets recorded in this session.</p>
+                                    </div>
+                                )}
+
+                                {!this.state.setsLoading && !this.state.setsError && grouped.map(({ exercise, sets }) => (
+                                    <div key={exercise.exercise_id} className="detail-card session-exercise">
+                                        <div className="session-exercise-head">
+                                            <button
+                                                className="session-exercise-name"
+                                                onClick={() => this.props.navigate(`/go-heavier/exercises/${exercise.exercise_id}`)}
+                                            >
+                                                {exercise.name}
+                                            </button>
+                                            <span className="session-exercise-summary">
+                                                {exercise.sets} sets · {this.formatCount(exercise.repetitions)} reps ·{" "}
+                                                {this.formatWeight(exercise.volume_kg)} · top {this.formatWeight(exercise.heaviest_weight_kg)}
+                                            </span>
+                                        </div>
+
+                                        <div className="set-table-wrapper">
+                                            <table className="set-table">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Set</th>
+                                                        <th>Reps</th>
+                                                        <th>Weight</th>
+                                                        <th>Bar</th>
+                                                        <th>Supp.</th>
+                                                        <th>Total</th>
+                                                        <th>Notes</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    {sets.map((set) => {
+                                                        const total = set.weight_kg +
+                                                            (set.bar_weight_kg || 0) +
+                                                            (set.supplementary_weight_kg || 0)
+                                                        return (
+                                                            <tr key={set.id}>
+                                                                <td>{set.index}</td>
+                                                                <td>{set.repetitions}</td>
+                                                                <td>{set.weight_kg.toFixed(1)}</td>
+                                                                <td>{set.bar_weight_kg ? set.bar_weight_kg.toFixed(1) : "-"}</td>
+                                                                <td>{set.supplementary_weight_kg ? set.supplementary_weight_kg.toFixed(1) : "-"}</td>
+                                                                <td><strong>{total.toFixed(1)}</strong></td>
+                                                                <td className="set-notes">{formatNotes(set.notes)}</td>
+                                                            </tr>
+                                                        )
+                                                    })}
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        )
+    }
+}
+
+// Wrapper component to use React Router hooks
+export default function SessionDetail() {
+    const { id } = useParams<{ id: string }>()
+    const navigate = useNavigate()
+    return <SessionDetailClass id={id!} navigate={navigate} />
+}

--- a/src/pages/go_heavier/Sessions.css
+++ b/src/pages/go_heavier/Sessions.css
@@ -1,0 +1,169 @@
+/* Sessions list */
+
+.sessions-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 24px;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.sessions-page.refreshing {
+    opacity: 0.5;
+}
+
+.sessions-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.session-card {
+    display: block;
+    width: 100%;
+    text-align: left;
+    font: inherit;
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 12px;
+    padding: 20px 24px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    transition: all 0.3s ease;
+    cursor: pointer;
+}
+
+.session-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+    border-color: #667eea;
+}
+
+.session-card-head {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px 16px;
+    padding-bottom: 16px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.session-when {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+}
+
+.session-date {
+    font-size: 1.0625rem;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.session-time {
+    font-size: 0.875rem;
+    color: #718096;
+}
+
+.session-location {
+    color: #5a6c7d;
+    font-size: 0.9375rem;
+}
+
+.session-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+    gap: 16px;
+}
+
+.session-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.session-metric-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #2c3e50;
+    line-height: 1.2;
+}
+
+.session-metric-label {
+    font-size: 0.6875rem;
+    color: #718096;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+@media (max-width: 767px) {
+    .sessions-page {
+        padding: 16px;
+    }
+
+    .session-card {
+        padding: 16px;
+    }
+
+    .session-metrics {
+        grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+        gap: 12px;
+    }
+
+    .session-metric-value {
+        font-size: 1.0625rem;
+    }
+}
+
+/* Session detail */
+.session-location-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.session-location-link:hover {
+    text-decoration: underline;
+}
+
+.session-exercise + .session-exercise {
+    margin-top: 16px;
+}
+
+.session-exercise-head {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px 16px;
+    padding-bottom: 12px;
+    margin-bottom: 8px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.session-exercise-name {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    font-weight: 600;
+    font-size: 1.0625rem;
+    color: #2c3e50;
+    cursor: pointer;
+}
+
+.session-exercise-name:hover {
+    color: #667eea;
+    text-decoration: underline;
+}
+
+.session-exercise-summary {
+    font-size: 0.875rem;
+    color: #718096;
+}

--- a/src/pages/go_heavier/Sessions.css
+++ b/src/pages/go_heavier/Sessions.css
@@ -167,3 +167,52 @@
     font-size: 0.875rem;
     color: #718096;
 }
+
+/* Session stats */
+.sessions-stats-detail {
+    margin-bottom: 32px;
+}
+
+@media (min-width: 768px) {
+    .sessions-stats-detail {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .sessions-weekdays {
+        grid-column: 1 / -1;
+    }
+}
+
+/* Add session button, matching the one on the locations page */
+.add-location-button {
+    position: fixed;
+    bottom: 32px;
+    right: 32px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 50px;
+    padding: 16px 32px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+    transition: all 0.3s ease;
+    z-index: 999;
+}
+
+.add-location-button:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 10px 30px rgba(102, 126, 234, 0.5);
+}
+
+.add-location-button:active {
+    transform: translateY(-1px);
+}
+
+.add-location-button .button-icon {
+    font-size: 1.3rem;
+}

--- a/src/pages/go_heavier/Sessions.tsx
+++ b/src/pages/go_heavier/Sessions.tsx
@@ -1,0 +1,208 @@
+import React from "react"
+import { useNavigate } from "react-router-dom"
+
+import GoHeavierNavBar from "../../components/go_heavier/NavBar"
+import { SESSIONS_CACHE_KEY, SessionSummary, fetchAllSessions } from "../../components/go_heavier/sessions"
+import "../GoHeavier.css"
+import "../../components/go_heavier/Stats.css"
+import "./Sessions.css"
+
+interface Props {
+    navigate: (path: string) => void
+}
+
+interface State {
+    loaded: boolean | null
+    sessions?: SessionSummary[]
+    isRefreshing: boolean
+}
+
+export class Sessions extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props)
+
+        const cachedData = sessionStorage.getItem(SESSIONS_CACHE_KEY)
+        const cachedSessions = cachedData ? JSON.parse(cachedData) : undefined
+
+        this.state = {
+            loaded: cachedSessions ? true : null,
+            sessions: cachedSessions,
+            isRefreshing: false
+        }
+    }
+
+    componentDidMount() {
+        // Cached sessions render straight away; the refresh button is the only
+        // thing that goes back to the API.
+        if (!this.state.sessions) {
+            this.fetchSessions()
+        }
+    }
+
+    fetchSessions = async (minDuration: number = 300) => {
+        const startedAt = Date.now()
+        const waitOut = () => new Promise<void>(resolve =>
+            setTimeout(resolve, Math.max(0, minDuration - (Date.now() - startedAt)))
+        )
+
+        this.setState({ isRefreshing: true })
+        try {
+            const sessions = await fetchAllSessions()
+            sessionStorage.setItem(SESSIONS_CACHE_KEY, JSON.stringify(sessions))
+
+            await waitOut()
+            this.setState({ sessions, loaded: true, isRefreshing: false })
+        } catch (error) {
+            console.error("Error fetching sessions:", error)
+            await waitOut()
+            this.setState({ loaded: false, isRefreshing: false })
+        }
+    }
+
+    handleRefresh = () => {
+        this.fetchSessions()
+    }
+
+    handleRetry = () => {
+        // Keep the loading state on screen long enough to be visible
+        this.fetchSessions(1000)
+    }
+
+    formatCount = (value: number): string => value.toLocaleString()
+
+    formatWeight = (value: number): string => `${Math.round(value).toLocaleString()} kg`
+
+    formatSessionDate = (value: string): string =>
+        new Date(value).toLocaleDateString("en-US", {
+            weekday: "short",
+            year: "numeric",
+            month: "short",
+            day: "numeric"
+        })
+
+    formatSessionTime = (value: string): string =>
+        new Date(value).toLocaleTimeString("en-US", {
+            hour: "2-digit",
+            minute: "2-digit"
+        })
+
+    render(): React.ReactNode {
+        const sessions = this.state.sessions ?? []
+        const totalSets = sessions.reduce((sum, session) => sum + session.sets, 0)
+        const totalVolume = sessions.reduce((sum, session) => sum + session.volume_kg, 0)
+
+        return (
+            <div className="center-container-grid">
+                <GoHeavierNavBar />
+                <div className="page-container">
+                    {this.state.loaded && !this.state.isRefreshing && (
+                        <button
+                            onClick={this.handleRefresh}
+                            className="refresh-arrow-button"
+                            title="Refresh"
+                        >
+                            ↻
+                        </button>
+                    )}
+
+                    {this.state.loaded === null && (
+                        <div className="loading-spinner">
+                            <div className="spinner"></div>
+                        </div>
+                    )}
+
+                    {this.state.loaded === false && (
+                        <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
+                            <h2>Failed to Load Sessions</h2>
+                            <p className="error-message">Unable to fetch sessions from server</p>
+                            <button onClick={this.handleRetry} disabled={this.state.isRefreshing}>
+                                {this.state.isRefreshing ? (
+                                    <>
+                                        <span className="button-spinner"></span>
+                                        Retrying...
+                                    </>
+                                ) : 'Retry'}
+                            </button>
+                        </div>
+                    )}
+
+                    {this.state.loaded && sessions.length === 0 && (
+                        <div className="header">
+                            <p>No sessions found.</p>
+                        </div>
+                    )}
+
+                    {this.state.loaded && sessions.length > 0 && (
+                        <div className={`sessions-page ${this.state.isRefreshing ? 'refreshing' : ''}`}>
+                            <div className="stats-grid">
+                                <div className="stat-tile">
+                                    <div className="stat-tile-value">{this.formatCount(sessions.length)}</div>
+                                    <div className="stat-tile-label">Sessions</div>
+                                </div>
+                                <div className="stat-tile">
+                                    <div className="stat-tile-value">{this.formatCount(totalSets)}</div>
+                                    <div className="stat-tile-label">Sets</div>
+                                </div>
+                                <div className="stat-tile">
+                                    <div className="stat-tile-value">{this.formatWeight(totalVolume)}</div>
+                                    <div className="stat-tile-label">Total volume</div>
+                                </div>
+                            </div>
+
+                            <div className="sessions-list">
+                                {sessions.map((session) => (
+                                    <button
+                                        key={session.id}
+                                        className="session-card"
+                                        onClick={() => this.props.navigate(`/go-heavier/sessions/${session.id}`)}
+                                    >
+                                        <div className="session-card-head">
+                                            <div className="session-when">
+                                                <span className="session-date">
+                                                    {this.formatSessionDate(session.workout_time)}
+                                                </span>
+                                                <span className="session-time">
+                                                    {this.formatSessionTime(session.workout_time)}
+                                                </span>
+                                            </div>
+                                            <span className="session-location">📍 {session.location}</span>
+                                        </div>
+
+                                        <div className="session-metrics">
+                                            <div className="session-metric">
+                                                <span className="session-metric-value">{session.exercises}</span>
+                                                <span className="session-metric-label">Exercises</span>
+                                            </div>
+                                            <div className="session-metric">
+                                                <span className="session-metric-value">{session.sets}</span>
+                                                <span className="session-metric-label">Sets</span>
+                                            </div>
+                                            <div className="session-metric">
+                                                <span className="session-metric-value">{this.formatCount(session.repetitions)}</span>
+                                                <span className="session-metric-label">Reps</span>
+                                            </div>
+                                            <div className="session-metric">
+                                                <span className="session-metric-value">{this.formatWeight(session.volume_kg)}</span>
+                                                <span className="session-metric-label">Volume</span>
+                                            </div>
+                                            <div className="session-metric">
+                                                <span className="session-metric-value">{this.formatWeight(session.heaviest_weight_kg)}</span>
+                                                <span className="session-metric-label">Heaviest</span>
+                                            </div>
+                                        </div>
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        )
+    }
+}
+
+// Wrapper component to use React Router hooks
+export default function SessionsWithNavigate() {
+    const navigate = useNavigate()
+    return <Sessions navigate={navigate} />
+}

--- a/src/pages/go_heavier/Sessions.tsx
+++ b/src/pages/go_heavier/Sessions.tsx
@@ -2,7 +2,16 @@ import React from "react"
 import { useNavigate } from "react-router-dom"
 
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
-import { SESSIONS_CACHE_KEY, SessionSummary, fetchAllSessions } from "../../components/go_heavier/sessions"
+import SessionForm from "../../components/go_heavier/SessionForm"
+import {
+    SESSIONS_CACHE_KEY,
+    SessionHighlight,
+    SessionStats,
+    SessionSummary,
+    WeekdayStats,
+    fetchAllSessions,
+    fetchSessionStats
+} from "../../components/go_heavier/sessions"
 import "../GoHeavier.css"
 import "../../components/go_heavier/Stats.css"
 import "./Sessions.css"
@@ -15,6 +24,10 @@ interface State {
     loaded: boolean | null
     sessions?: SessionSummary[]
     isRefreshing: boolean
+    stats: SessionStats | null
+    statsLoading: boolean
+    statsError: string | null
+    showForm: boolean
 }
 
 export class Sessions extends React.Component<Props, State> {
@@ -27,7 +40,11 @@ export class Sessions extends React.Component<Props, State> {
         this.state = {
             loaded: cachedSessions ? true : null,
             sessions: cachedSessions,
-            isRefreshing: false
+            isRefreshing: false,
+            stats: null,
+            statsLoading: true,
+            statsError: null,
+            showForm: false
         }
     }
 
@@ -36,6 +53,18 @@ export class Sessions extends React.Component<Props, State> {
         // thing that goes back to the API.
         if (!this.state.sessions) {
             this.fetchSessions()
+        }
+        this.fetchStats()
+    }
+
+    fetchStats = async () => {
+        this.setState({ statsLoading: true, statsError: null })
+        try {
+            const stats = await fetchSessionStats()
+            this.setState({ stats, statsLoading: false })
+        } catch (error) {
+            console.error("Error fetching session stats:", error)
+            this.setState({ statsError: (error as Error).message, statsLoading: false })
         }
     }
 
@@ -61,16 +90,63 @@ export class Sessions extends React.Component<Props, State> {
 
     handleRefresh = () => {
         this.fetchSessions()
+        this.fetchStats()
     }
 
     handleRetry = () => {
         // Keep the loading state on screen long enough to be visible
         this.fetchSessions(1000)
+        this.fetchStats()
     }
+
+    formatDays = (value: number | null): string =>
+        value === null || value === undefined ? "\u2014" : `${value.toFixed(1)} days`
+
+    // The bar length encodes sessions, the same measure the row is labelled with.
+    renderWeekdays = (weekdays: WeekdayStats[]): React.ReactNode => {
+        const busiest = Math.max(...weekdays.map(day => day.sessions), 1)
+
+        return weekdays.map((day) => (
+            <li key={day.weekday} className="top-list-item">
+                <div className="top-list-head">
+                    <span className="top-list-name">{day.weekday}</span>
+                    <span className="top-list-metric">
+                        {this.formatCount(day.sessions)} {day.sessions === 1 ? "session" : "sessions"}
+                    </span>
+                </div>
+                <div className="top-list-bar-track">
+                    <div
+                        className="top-list-bar"
+                        style={{ width: `${(day.sessions / busiest) * 100}%` }}
+                    />
+                </div>
+                <div className="top-list-meta">
+                    {this.formatCount(day.sets)} sets · {this.formatWeight(day.volume_kg)}
+                </div>
+            </li>
+        ))
+    }
+
+    renderHighlight = (title: string, highlight: SessionHighlight) => (
+        <div className="detail-card">
+            <h4 className="top-list-title">{title}</h4>
+            <button
+                className="session-exercise-name"
+                onClick={() => this.props.navigate(`/go-heavier/sessions/${highlight.id}`)}
+            >
+                {this.formatSessionDate(highlight.workout_time)}
+            </button>
+            <div className="top-list-meta">
+                📍 {highlight.location} · {this.formatCount(highlight.sets)} sets ·{" "}
+                {this.formatWeight(highlight.volume_kg)}
+            </div>
+        </div>
+    )
 
     formatCount = (value: number): string => value.toLocaleString()
 
-    formatWeight = (value: number): string => `${Math.round(value).toLocaleString()} kg`
+    formatWeight = (value: number | null): string =>
+        value === null || value === undefined ? "\u2014" : `${Math.round(value).toLocaleString()} kg`
 
     formatSessionDate = (value: string): string =>
         new Date(value).toLocaleDateString("en-US", {
@@ -88,8 +164,7 @@ export class Sessions extends React.Component<Props, State> {
 
     render(): React.ReactNode {
         const sessions = this.state.sessions ?? []
-        const totalSets = sessions.reduce((sum, session) => sum + session.sets, 0)
-        const totalVolume = sessions.reduce((sum, session) => sum + session.volume_kg, 0)
+        const stats = this.state.stats
 
         return (
             <div className="center-container-grid">
@@ -126,6 +201,28 @@ export class Sessions extends React.Component<Props, State> {
                         </div>
                     )}
 
+                    {this.state.loaded && (
+                        <button
+                            className="add-location-button"
+                            onClick={() => this.setState({ showForm: true })}
+                        >
+                            <span className="button-icon">➕</span>
+                            Add New Session
+                        </button>
+                    )}
+
+                    {this.state.showForm && (
+                        <SessionForm
+                            onClose={() => this.setState({ showForm: false })}
+                            onSuccess={(session) => {
+                                this.setState({ showForm: false })
+                                // The new session is empty, so open it ready for sets.
+                                sessionStorage.removeItem(SESSIONS_CACHE_KEY)
+                                this.props.navigate(`/go-heavier/sessions/${session.id}`)
+                            }}
+                        />
+                    )}
+
                     {this.state.loaded && sessions.length === 0 && (
                         <div className="header">
                             <p>No sessions found.</p>
@@ -134,20 +231,61 @@ export class Sessions extends React.Component<Props, State> {
 
                     {this.state.loaded && sessions.length > 0 && (
                         <div className={`sessions-page ${this.state.isRefreshing ? 'refreshing' : ''}`}>
-                            <div className="stats-grid">
-                                <div className="stat-tile">
-                                    <div className="stat-tile-value">{this.formatCount(sessions.length)}</div>
-                                    <div className="stat-tile-label">Sessions</div>
+                            {this.state.statsLoading && !this.state.stats && (
+                                <div className="detail-card">
+                                    <p>Loading stats...</p>
                                 </div>
-                                <div className="stat-tile">
-                                    <div className="stat-tile-value">{this.formatCount(totalSets)}</div>
-                                    <div className="stat-tile-label">Sets</div>
+                            )}
+
+                            {this.state.statsError && (
+                                <div className="detail-card">
+                                    <p className="error-message">{this.state.statsError}</p>
                                 </div>
-                                <div className="stat-tile">
-                                    <div className="stat-tile-value">{this.formatWeight(totalVolume)}</div>
-                                    <div className="stat-tile-label">Total volume</div>
-                                </div>
-                            </div>
+                            )}
+
+                            {!this.state.statsError && stats && (
+                                <>
+                                    <div className="stats-grid">
+                                        <div className="stat-tile">
+                                            <div className="stat-tile-value">{this.formatCount(stats.sessions)}</div>
+                                            <div className="stat-tile-label">Sessions</div>
+                                        </div>
+                                        <div className="stat-tile">
+                                            <div className="stat-tile-value">{stats.average_sets_per_session.toFixed(1)}</div>
+                                            <div className="stat-tile-label">Sets / session</div>
+                                        </div>
+                                        <div className="stat-tile">
+                                            <div className="stat-tile-value">{stats.average_exercises_per_session.toFixed(1)}</div>
+                                            <div className="stat-tile-label">Exercises / session</div>
+                                        </div>
+                                        <div className="stat-tile">
+                                            <div className="stat-tile-value">{this.formatWeight(stats.average_volume_kg_per_session)}</div>
+                                            <div className="stat-tile-label">Volume / session</div>
+                                        </div>
+                                        <div className="stat-tile">
+                                            <div className="stat-tile-value">{this.formatDays(stats.average_days_between_sessions)}</div>
+                                            <div className="stat-tile-label">Typical gap</div>
+                                        </div>
+                                        <div className="stat-tile">
+                                            <div className="stat-tile-value">{this.formatDays(stats.longest_gap_days)}</div>
+                                            <div className="stat-tile-label">Longest gap</div>
+                                        </div>
+                                    </div>
+
+                                    <div className="stats-detail sessions-stats-detail">
+                                        {stats.busiest_session && this.renderHighlight("Busiest session", stats.busiest_session)}
+                                        {stats.heaviest_session && this.renderHighlight("Heaviest session", stats.heaviest_session)}
+                                        {(stats.by_weekday ?? []).length > 0 && (
+                                            <div className="detail-card sessions-weekdays">
+                                                <h4 className="top-list-title">By day of the week</h4>
+                                                <ol className="top-list">
+                                                    {this.renderWeekdays(stats.by_weekday ?? [])}
+                                                </ol>
+                                            </div>
+                                        )}
+                                    </div>
+                                </>
+                            )}
 
                             <div className="sessions-list">
                                 {sessions.map((session) => (

--- a/src/pages/go_heavier/Stats.tsx
+++ b/src/pages/go_heavier/Stats.tsx
@@ -1,0 +1,330 @@
+import React from "react"
+import { useNavigate } from "react-router-dom"
+
+import GoHeavierNavBar from "../../components/go_heavier/NavBar"
+import BarChart, { BarChartPoint } from "../../components/go_heavier/BarChart"
+import { API_URL } from "../../configs"
+import {
+    SessionStats,
+    SessionSummary,
+    fetchAllSessions,
+    fetchSessionStats
+} from "../../components/go_heavier/sessions"
+import "../GoHeavier.css"
+import "../../components/go_heavier/Stats.css"
+import "./Sessions.css"
+import "./StatsPage.css"
+
+interface RankedItem {
+    name: string
+    sessions: number
+    sets: number
+    repetitions: number
+    volume_kg: number
+}
+
+interface WorkoutTotals {
+    total_sets: number
+    total_repetitions: number
+    total_volume_kg: number
+    heaviest_weight_kg: number | null
+    distinct_exercises: number
+    distinct_locations: number
+    top_exercises?: RankedItem[]
+    top_locations?: RankedItem[]
+}
+
+interface MonthPoint {
+    label: string
+    visits: number
+    sets: number
+    repetitions: number
+    volume_kg: number
+}
+
+interface Props {
+    navigate: (path: string) => void
+}
+
+interface State {
+    sessions: SessionSummary[] | null
+    stats: SessionStats | null
+    totals: WorkoutTotals | null
+    loaded: boolean | null
+    isRefreshing: boolean
+}
+
+export class Stats extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props)
+        this.state = {
+            sessions: null,
+            stats: null,
+            totals: null,
+            loaded: null,
+            isRefreshing: false
+        }
+    }
+
+    componentDidMount() {
+        this.fetchEverything()
+    }
+
+    fetchEverything = async (minDuration: number = 300) => {
+        const startedAt = Date.now()
+        const waitOut = () => new Promise<void>(resolve =>
+            setTimeout(resolve, Math.max(0, minDuration - (Date.now() - startedAt)))
+        )
+
+        this.setState({ isRefreshing: true })
+        try {
+            const [sessions, stats, totalsRes] = await Promise.all([
+                fetchAllSessions(),
+                fetchSessionStats(),
+                fetch(`${API_URL}/go-heavier/workouts/stats`)
+            ])
+
+            if (!totalsRes.ok) {
+                throw new Error("Failed to load totals")
+            }
+            const totals = await totalsRes.json()
+
+            await waitOut()
+            this.setState({ sessions, stats, totals, loaded: true, isRefreshing: false })
+        } catch (error) {
+            console.error("Error fetching stats:", error)
+            await waitOut()
+            this.setState({ loaded: false, isRefreshing: false })
+        }
+    }
+
+    handleRefresh = () => {
+        this.fetchEverything()
+    }
+
+    handleRetry = () => {
+        // Keep the loading state on screen long enough to be visible
+        this.fetchEverything(1000)
+    }
+
+    formatCount = (value: number): string => Math.round(value).toLocaleString()
+
+    formatWeight = (value: number | null): string =>
+        value === null || value === undefined ? "—" : `${Math.round(value).toLocaleString()} kg`
+
+    // Tonnes keep the volume axis readable; kilogram totals run to six figures.
+    formatTonnes = (value: number): string => `${(value / 1000).toFixed(1)}t`
+
+    formatDays = (value: number | null): string =>
+        value === null || value === undefined ? "—" : `${value.toFixed(1)} days`
+
+    // Every month between the first and last session, including the empty ones —
+    // dropping a quiet month would flatter the trend.
+    getMonths = (): MonthPoint[] => {
+        const sessions = this.state.sessions ?? []
+        if (sessions.length === 0) {
+            return []
+        }
+
+        const times = sessions.map(session => new Date(session.workout_time))
+        const first = new Date(Math.min(...times.map(time => time.getTime())))
+        const last = new Date(Math.max(...times.map(time => time.getTime())))
+
+        const months: MonthPoint[] = []
+        const cursor = new Date(first.getFullYear(), first.getMonth(), 1)
+        const end = new Date(last.getFullYear(), last.getMonth(), 1)
+
+        while (cursor <= end) {
+            const year = cursor.getFullYear()
+            const month = cursor.getMonth()
+
+            const inMonth = sessions.filter(session => {
+                const when = new Date(session.workout_time)
+                return when.getFullYear() === year && when.getMonth() === month
+            })
+
+            months.push({
+                label: cursor.toLocaleDateString("en-US", { month: "short", year: "2-digit" }),
+                visits: inMonth.length,
+                sets: inMonth.reduce((total, session) => total + session.sets, 0),
+                repetitions: inMonth.reduce((total, session) => total + session.repetitions, 0),
+                volume_kg: inMonth.reduce((total, session) => total + session.volume_kg, 0)
+            })
+
+            cursor.setMonth(cursor.getMonth() + 1)
+        }
+
+        return months
+    }
+
+    toPoints = (months: MonthPoint[], key: keyof Omit<MonthPoint, "label">): BarChartPoint[] =>
+        months.map(month => ({ label: month.label, value: month[key] }))
+
+    renderRanked = (title: string, items: RankedItem[]) => {
+        const most = Math.max(...items.map(item => item.sessions), 1)
+
+        return (
+            <div className="detail-card">
+                <h4 className="top-list-title">{title}</h4>
+                <ol className="top-list">
+                    {items.map(item => (
+                        <li key={item.name} className="top-list-item">
+                            <div className="top-list-head">
+                                <span className="top-list-name">{item.name}</span>
+                                <span className="top-list-metric">
+                                    {this.formatCount(item.sessions)} sessions
+                                </span>
+                            </div>
+                            <div className="top-list-bar-track">
+                                <div
+                                    className="top-list-bar"
+                                    style={{ width: `${(item.sessions / most) * 100}%` }}
+                                />
+                            </div>
+                            <div className="top-list-meta">
+                                {this.formatCount(item.sets)} sets · {this.formatCount(item.repetitions)} reps ·{" "}
+                                {this.formatWeight(item.volume_kg)}
+                            </div>
+                        </li>
+                    ))}
+                </ol>
+            </div>
+        )
+    }
+
+    render(): React.ReactNode {
+        const { stats, totals } = this.state
+        const months = this.getMonths()
+        // 13 months of labels collide on a narrow screen; thin them out.
+        const labelEvery = months.length > 12 ? 2 : 1
+        const weekdays = stats?.by_weekday ?? []
+
+        return (
+            <div className="center-container-grid">
+                <GoHeavierNavBar />
+                <div className="page-container">
+                    {this.state.loaded && !this.state.isRefreshing && (
+                        <button
+                            onClick={this.handleRefresh}
+                            className="refresh-arrow-button"
+                            title="Refresh"
+                        >
+                            ↻
+                        </button>
+                    )}
+
+                    {this.state.loaded === null && (
+                        <div className="loading-spinner">
+                            <div className="spinner"></div>
+                        </div>
+                    )}
+
+                    {this.state.loaded === false && (
+                        <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
+                            <h2>Failed to Load Stats</h2>
+                            <p className="error-message">Unable to fetch stats from server</p>
+                            <button onClick={this.handleRetry} disabled={this.state.isRefreshing}>
+                                {this.state.isRefreshing ? (
+                                    <>
+                                        <span className="button-spinner"></span>
+                                        Retrying...
+                                    </>
+                                ) : 'Retry'}
+                            </button>
+                        </div>
+                    )}
+
+                    {this.state.loaded && stats && (
+                        <div className={`stats-page ${this.state.isRefreshing ? 'refreshing' : ''}`}>
+                            <div className="dashboard-hero">
+                                <h1>📈 Training Stats</h1>
+                                <p className="dashboard-tagline">
+                                    Every session logged, from {this.formatMonth(stats.first_session)} to{" "}
+                                    {this.formatMonth(stats.last_session)}.
+                                </p>
+                            </div>
+
+                            <div className="stats-grid">
+                                <div className="stat-tile">
+                                    <div className="stat-tile-value">{this.formatCount(stats.sessions)}</div>
+                                    <div className="stat-tile-label">Sessions</div>
+                                </div>
+                                <div className="stat-tile">
+                                    <div className="stat-tile-value">{this.formatCount(totals?.total_sets ?? 0)}</div>
+                                    <div className="stat-tile-label">Sets</div>
+                                </div>
+                                <div className="stat-tile">
+                                    <div className="stat-tile-value">{this.formatCount(totals?.total_repetitions ?? 0)}</div>
+                                    <div className="stat-tile-label">Reps</div>
+                                </div>
+                                <div className="stat-tile">
+                                    <div className="stat-tile-value">{this.formatTonnes(totals?.total_volume_kg ?? 0)}</div>
+                                    <div className="stat-tile-label">Total volume</div>
+                                </div>
+                                <div className="stat-tile">
+                                    <div className="stat-tile-value">{this.formatWeight(totals?.heaviest_weight_kg ?? null)}</div>
+                                    <div className="stat-tile-label">Heaviest lift</div>
+                                </div>
+                                <div className="stat-tile">
+                                    <div className="stat-tile-value">{this.formatDays(stats.average_days_between_sessions)}</div>
+                                    <div className="stat-tile-label">Typical gap</div>
+                                </div>
+                            </div>
+
+                            <div className="charts-grid">
+                                <BarChart
+                                    title="Visits per month"
+                                    subtitle="Sessions logged in each month"
+                                    data={this.toPoints(months, "visits")}
+                                    formatValue={this.formatCount}
+                                    labelEvery={labelEvery}
+                                />
+                                <BarChart
+                                    title="Sets per month"
+                                    subtitle="Every set logged in each month"
+                                    data={this.toPoints(months, "sets")}
+                                    formatValue={this.formatCount}
+                                    labelEvery={labelEvery}
+                                />
+                                <BarChart
+                                    title="Volume per month"
+                                    subtitle="Weight moved, reps multiplied by weight"
+                                    data={this.toPoints(months, "volume_kg")}
+                                    formatValue={this.formatTonnes}
+                                    labelEvery={labelEvery}
+                                />
+                                {weekdays.length > 0 && (
+                                    <BarChart
+                                        title="Visits by day of the week"
+                                        subtitle="Which days you train on"
+                                        data={weekdays.map(day => ({
+                                            label: day.weekday.slice(0, 3),
+                                            value: day.sessions
+                                        }))}
+                                        formatValue={this.formatCount}
+                                    />
+                                )}
+                            </div>
+
+                            <div className="stats-detail">
+                                {(totals?.top_exercises ?? []).length > 0 &&
+                                    this.renderRanked("Most trained exercises", totals!.top_exercises!)}
+                                {(totals?.top_locations ?? []).length > 0 &&
+                                    this.renderRanked("Most visited gyms", totals!.top_locations!)}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+        )
+    }
+
+    formatMonth = (value: string | null): string =>
+        !value ? "—" : new Date(value).toLocaleDateString("en-US", { month: "long", year: "numeric" })
+}
+
+// Wrapper component to use React Router hooks
+export default function StatsWithNavigate() {
+    const navigate = useNavigate()
+    return <Stats navigate={navigate} />
+}

--- a/src/pages/go_heavier/StatsPage.css
+++ b/src/pages/go_heavier/StatsPage.css
@@ -1,0 +1,32 @@
+/* Training stats page */
+
+.stats-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 24px;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.stats-page.refreshing {
+    opacity: 0.5;
+}
+
+.charts-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 24px;
+    margin-bottom: 32px;
+}
+
+@media (min-width: 900px) {
+    .charts-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 767px) {
+    .stats-page {
+        padding: 16px;
+    }
+}

--- a/src/pages/go_heavier/Workouts.tsx
+++ b/src/pages/go_heavier/Workouts.tsx
@@ -3,23 +3,29 @@ import { useNavigate, useSearchParams } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import WorkoutForm from "../../components/go_heavier/WorkoutForm"
 import { API_URL, WORKOUTS_CACHE_KEY, formatNotes } from "../../configs"
+import { SessionSummary, fetchAllSessions, indexSessions } from "../../components/go_heavier/sessions"
 import "../GoHeavier.css"
 import "./Workouts.css"
 
 interface WorkoutData {
     id: string
-    location_id: string
+    session_id: string
     exercise_id: string
-    exercise_index: number
-    workout_time: string
     index: number
     repetitions: number
     weight_kg: number
-    bar_weight_kg: number
-    supplementary_weight_kg: number
-    notes: string
+    bar_weight_kg: number | null
+    supplementary_weight_kg: number | null
+    notes: string | null
     created_at: string
-    updated_at: string
+    updated_at: string | null
+}
+
+// A set plus the time and location resolved from its session.
+type WorkoutRow = WorkoutData & {
+    workout_time: string | null
+    location_id: string | null
+    location: string | null
 }
 
 // Safety cap on the page walk so a misbehaving endpoint can't loop forever.
@@ -37,6 +43,7 @@ const dedupeById = (workouts: WorkoutData[]): WorkoutData[] => mergeById([], wor
 interface State {
     configLoaded: boolean | null
     workouts?: WorkoutData[]
+    sessionsById: Record<string, SessionSummary>
     locations?: any[]
     exercises?: any[]
     showForm?: boolean
@@ -85,6 +92,7 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         this.state = {
             configLoaded: cachedWorkouts ? true : null,
             workouts: cachedWorkouts,
+            sessionsById: {},
             locations: [],
             exercises: [],
             showForm: false,
@@ -137,8 +145,9 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
 
         this.setState({ isRefreshing: true })
         try {
-            const [workouts, locationsRes, exercisesRes] = await Promise.all([
+            const [workouts, sessions, locationsRes, exercisesRes] = await Promise.all([
                 this.fetchAllWorkouts(),
+                fetchAllSessions(),
                 fetch(`${API_URL}/go-heavier/locations`),
                 fetch(`${API_URL}/go-heavier/exercises`)
             ])
@@ -151,6 +160,7 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
             await waitOut()
             this.setState({ 
                 workouts, 
+                sessionsById: indexSessions(sessions),
                 locations,
                 exercises,
                 configLoaded: true, 
@@ -177,14 +187,16 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         if (!this.state.hasFetchedOnce) {
             this.handleRefresh()
         } else {
-            // If workouts are cached, still need to fetch locations and exercises for name lookup
-            this.fetchLocationsAndExercises()
+            // Cached sets carry only a session_id, so the sessions still have to be
+            // fetched to resolve each row's time and location.
+            this.fetchSupportingData()
         }
     }
 
-    fetchLocationsAndExercises = async () => {
+    fetchSupportingData = async () => {
         try {
-            const [locationsRes, exercisesRes] = await Promise.all([
+            const [sessions, locationsRes, exercisesRes] = await Promise.all([
+                fetchAllSessions(),
                 fetch(`${API_URL}/go-heavier/locations`),
                 fetch(`${API_URL}/go-heavier/exercises`)
             ])
@@ -192,15 +204,10 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
             const locations = await locationsRes.json()
             const exercises = await exercisesRes.json()
             
-            this.setState({ locations, exercises })
+            this.setState({ sessionsById: indexSessions(sessions), locations, exercises })
         } catch (error) {
-            console.error("Error fetching locations/exercises:", error)
+            console.error("Error fetching sessions/locations/exercises:", error)
         }
-    }
-
-    getLocationName = (locationId: string): string => {
-        const location = this.state.locations?.find(l => l.id === locationId)
-        return location ? location.name : 'Unknown Location'
     }
 
     getExerciseName = (exerciseId: string): string => {
@@ -208,7 +215,10 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         return exercise ? exercise.name : 'Unknown Exercise'
     }
 
-    formatDateTime = (dateString: string): string => {
+    formatDateTime = (dateString: string | null): string => {
+        if (!dateString) {
+            return "\u2014"
+        }
         const date = new Date(dateString)
         return date.toLocaleDateString("en-US", {
             year: "numeric",
@@ -314,15 +324,27 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         this.props.setSearchParams(params)
     }
 
-    getFilteredWorkouts = (): WorkoutData[] => {
+    // The time and location live on the session a set belongs to.
+    resolveSessions = (workouts: WorkoutData[]): WorkoutRow[] =>
+        workouts.map(workout => {
+            const session = this.state.sessionsById[workout.session_id]
+            return {
+                ...workout,
+                workout_time: session?.workout_time ?? null,
+                location_id: session?.location_id ?? null,
+                location: session?.location ?? null
+            }
+        })
+
+    getFilteredWorkouts = (): WorkoutRow[] => {
         if (!this.state.workouts) return []
 
-        let filtered = [...this.state.workouts]
+        let filtered = this.resolveSessions(this.state.workouts)
 
         // Apply date filter if set
         if (this.state.dateFilter.startDate || this.state.dateFilter.endDate) {
             filtered = filtered.filter(workout => {
-                // Parse workout time - handle both ISO string and other formats
+                if (!workout.workout_time) return false
                 const workoutDate = new Date(workout.workout_time)
                 
                 // Reset time to start of day for comparison
@@ -354,7 +376,7 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         // Apply location filter
         if (this.state.filters.locationIds.length > 0) {
             filtered = filtered.filter(workout => 
-                this.state.filters.locationIds.includes(workout.location_id)
+                workout.location_id !== null && this.state.filters.locationIds.includes(workout.location_id)
             )
         }
 
@@ -550,7 +572,16 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                                         return (
                                             <tr key={workout.id}>
                                                 <td className="workout-time">
-                                                    {this.formatDateTime(workout.workout_time)}
+                                                    <a
+                                                        href={`/go-heavier/sessions/${workout.session_id}`}
+                                                        onClick={(e) => {
+                                                            e.preventDefault()
+                                                            this.props.navigate(`/go-heavier/sessions/${workout.session_id}`)
+                                                        }}
+                                                        className="table-link"
+                                                    >
+                                                        {this.formatDateTime(workout.workout_time)}
+                                                    </a>
                                                 </td>
                                                 <td className="workout-exercise">
                                                     <a 
@@ -565,16 +596,18 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                                                     </a>
                                                 </td>
                                                 <td className="workout-location">
-                                                    <a 
-                                                        href={`/go-heavier/locations/${workout.location_id}`}
-                                                        onClick={(e) => {
-                                                            e.preventDefault()
-                                                            this.props.navigate(`/go-heavier/locations/${workout.location_id}`)
-                                                        }}
-                                                        className="table-link"
-                                                    >
-                                                        {this.getLocationName(workout.location_id)}
-                                                    </a>
+                                                    {workout.location_id ? (
+                                                        <a 
+                                                            href={`/go-heavier/locations/${workout.location_id}`}
+                                                            onClick={(e) => {
+                                                                e.preventDefault()
+                                                                this.props.navigate(`/go-heavier/locations/${workout.location_id}`)
+                                                            }}
+                                                            className="table-link"
+                                                        >
+                                                            {workout.location}
+                                                        </a>
+                                                    ) : '\u2014'}
                                                 </td>
                                                 <td className="workout-set">
                                                     {workout.index}


### PR DESCRIPTION
## Summary

Three commits. The first carries over from #17, which merged before it was pushed.

### Sessions replace locations on the workout model (`5bf1599`)

A set no longer carries a location or a time — it belongs to a session, and the session carries both.

- New sessions list and session detail page, the latter grouping a session's sets by exercise from `by_exercise`.
- Shared session type, page walk, and lookup in `components/go_heavier/sessions.ts`, with concurrent walks deduped so StrictMode's double mount doesn't double-fetch.
- Workouts page resolves each row's time and location through its session; the time column links to that session.
- Exercise detail uses the `exercise_id` filter (no longer 500s) and treats the latest session as the latest workout.
- Workout form picks an existing session instead of a location and a time.
- Dashboard gains a sessions card and takes its workout count from the sessions.

### Deleting goes admin-only (`74122d7`)

Delete Location and Delete Exercise are disabled and muted, with a title explaining why. Handlers and the confirmation dialog stay for when the admin check exists.

### Stats page, session stats, session creation (`e443c1b`)

- **New stats page** at `/go-heavier/stats`: visits, sets, and volume per month, plus visits by day of the week, over a KPI row, with ranked exercises and gyms beneath.
- **`BarChart`** draws columns in plain HTML — no chart dependency. One series per chart so the title carries identity and no legend is needed; 24px cap with a rounded data-end and square baseline; 2px gap between columns; recessive hairline gridlines; only the peak column labelled; hover tooltip plus a Table toggle so no value is hover-gated. Volume gets its own chart rather than sharing an axis with counts.
- Months with no sessions are kept as empty columns. Jan–Mar 26 are genuinely empty (the 113-day gap the stats report), and dropping them would flatter the trend.
- Sessions list now shows `/sessions/stats` figures instead of totals summed in the browser.
- Sessions can be created from the app now that `POST /sessions` exists.

## Bug found while testing

The workout form sent `bar_weight_kg: 0`. The schema requires `> 0` or null, so **every submission 422'd**. The payload is now built explicitly — null for an absent bar weight, supplementary weight, or note — and bounds are validated up front so a mistake reads as a message rather than a raw 422. The "weight cannot be negative" check is gone: negative weight is valid for assisted machines.

`SessionSummary.heaviest_weight_kg` is now nullable — an empty session returns null despite the schema marking it required. Worth a look server-side.

## Testing

- `tsc --noEmit` and `eslint` clean; `CI=true react-scripts build` compiles with no warnings.
- Session creation exercised against the dev API: `POST /sessions` → 201, appears at the top of the list, local 18:30 correctly sent as 17:30Z. Adding a set with the corrected payload → 201, session then reporting 1 set, 8 reps, 320 kg, `by_exercise` populated. Test set deleted afterwards; an empty test session remains since there is no `DELETE /sessions`.
- Monthly buckets reconcile against the API: 13 months, visits summing to 64 (= total sessions), sets to 1,261 (= `total_sets`).
- The chart hue `#667eea` passes the palette validator on a light surface (lightness band, chroma floor, ≥3:1 contrast).
- No browser tooling this session, so the rendered page has not been eyeballed — axis labels on a narrow viewport are the most likely spot to need tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)