### PR TITLE
Go Heavier: log a workout, and edit a session in place

### DIFF
--- a/src/components/go_heavier/ExercisePicker.css
+++ b/src/components/go_heavier/ExercisePicker.css
@@ -1,0 +1,64 @@
+/* Searchable exercise dropdown */
+
+.exercise-picker {
+    position: relative;
+    width: 100%;
+}
+
+.exercise-picker-input {
+    width: 100%;
+}
+
+.exercise-picker-list {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    max-height: 220px;
+    overflow-y: auto;
+    margin: 0;
+    padding: 4px;
+    list-style: none;
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    z-index: 20;
+}
+
+.exercise-picker-option {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    width: 100%;
+    padding: 8px 10px;
+    background: none;
+    border: none;
+    border-radius: 6px;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.exercise-picker-option.highlighted {
+    background: #eef0fb;
+}
+
+.exercise-picker-name {
+    color: #2c3e50;
+    font-size: 0.9375rem;
+}
+
+.exercise-picker-muscle {
+    color: #a0aec0;
+    font-size: 0.75rem;
+    text-transform: capitalize;
+    flex-shrink: 0;
+}
+
+.exercise-picker-empty {
+    padding: 10px;
+    color: #a0aec0;
+    font-size: 0.875rem;
+}

--- a/src/components/go_heavier/ExercisePicker.tsx
+++ b/src/components/go_heavier/ExercisePicker.tsx
@@ -1,0 +1,155 @@
+import React from "react"
+
+import { filterExercises } from "./logWorkout"
+import "./ExercisePicker.css"
+
+export interface PickableExercise {
+    id: string
+    name: string
+    muscle_group?: string
+}
+
+interface Props {
+    exercises: PickableExercise[]
+    value: string
+    onChange: (exerciseId: string) => void
+    label?: string
+}
+
+let nextListId = 0
+
+interface State {
+    query: string
+    open: boolean
+    highlighted: number
+}
+
+export default class ExercisePicker extends React.Component<Props, State> {
+    private containerRef = React.createRef<HTMLDivElement>()
+    private listId = `exercise-picker-list-${(nextListId += 1)}`
+
+    constructor(props: Props) {
+        super(props)
+        this.state = {
+            query: "",
+            open: false,
+            highlighted: 0
+        }
+    }
+
+    componentDidMount() {
+        document.addEventListener("mousedown", this.handleOutsideClick)
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener("mousedown", this.handleOutsideClick)
+    }
+
+    handleOutsideClick = (event: MouseEvent) => {
+        if (this.state.open && !this.containerRef.current?.contains(event.target as Node)) {
+            this.close()
+        }
+    }
+
+    selectedName = (): string => {
+        const selected = this.props.exercises.find(exercise => exercise.id === this.props.value)
+        return selected ? selected.name : ""
+    }
+
+    matches = (): PickableExercise[] => filterExercises(this.props.exercises, this.state.query)
+
+    open = () => {
+        this.setState({ open: true, query: "", highlighted: 0 })
+    }
+
+    close = () => {
+        this.setState({ open: false, query: "" })
+    }
+
+    choose = (exercise: PickableExercise) => {
+        this.props.onChange(exercise.id)
+        this.close()
+    }
+
+    handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        const matches = this.matches()
+
+        if (event.key === "ArrowDown") {
+            event.preventDefault()
+            this.setState({ open: true, highlighted: Math.min(this.state.highlighted + 1, matches.length - 1) })
+            return
+        }
+
+        if (event.key === "ArrowUp") {
+            event.preventDefault()
+            this.setState({ highlighted: Math.max(this.state.highlighted - 1, 0) })
+            return
+        }
+
+        if (event.key === "Enter") {
+            const choice = matches[this.state.highlighted]
+            if (this.state.open && choice) {
+                event.preventDefault()
+                this.choose(choice)
+            }
+            return
+        }
+
+        if (event.key === "Escape" && this.state.open) {
+            event.preventDefault()
+            this.close()
+        }
+    }
+
+    render(): React.ReactNode {
+        const matches = this.matches()
+        const selectedName = this.selectedName()
+
+        return (
+            <div className="exercise-picker" ref={this.containerRef}>
+                <input
+                    type="text"
+                    className="exercise-picker-input"
+                    role="combobox"
+                    aria-expanded={this.state.open}
+                    aria-controls={this.listId}
+                    aria-label={this.props.label ?? "Exercise"}
+                    placeholder={selectedName || "Search exercises..."}
+                    value={this.state.open ? this.state.query : selectedName}
+                    onFocus={this.open}
+                    onChange={(e) => this.setState({ open: true, query: e.target.value, highlighted: 0 })}
+                    onKeyDown={this.handleKeyDown}
+                />
+
+                {this.state.open && (
+                    <ul id={this.listId} className="exercise-picker-list" role="listbox">
+                        {matches.length === 0 && (
+                            <li className="exercise-picker-empty">No exercises match</li>
+                        )}
+                        {matches.map((exercise, index) => (
+                            <li key={exercise.id}>
+                                <button
+                                    type="button"
+                                    role="option"
+                                    aria-selected={exercise.id === this.props.value}
+                                    className={
+                                        index === this.state.highlighted
+                                            ? "exercise-picker-option highlighted"
+                                            : "exercise-picker-option"
+                                    }
+                                    onMouseEnter={() => this.setState({ highlighted: index })}
+                                    onClick={() => this.choose(exercise)}
+                                >
+                                    <span className="exercise-picker-name">{exercise.name}</span>
+                                    {exercise.muscle_group && (
+                                        <span className="exercise-picker-muscle">{exercise.muscle_group}</span>
+                                    )}
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        )
+    }
+}

--- a/src/components/go_heavier/LogWorkoutWizard.css
+++ b/src/components/go_heavier/LogWorkoutWizard.css
@@ -1,0 +1,160 @@
+/* Log-a-workout popup: wider than the simple forms, since each set is a row */
+
+.log-workout-wizard {
+    max-width: 860px;
+    width: 100%;
+}
+
+.wizard-steps {
+    display: flex;
+    gap: 8px;
+    list-style: none;
+    margin: 0 0 20px 0;
+    padding: 0;
+}
+
+.wizard-steps li {
+    flex: 1;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: #f4f5f7;
+    color: #a0aec0;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-align: center;
+}
+
+.wizard-steps li.current {
+    background: #eef0fb;
+    color: #4c5bd4;
+}
+
+.wizard-steps li.done {
+    background: #eef0fb;
+    color: #a0aec0;
+}
+
+.wizard-hint {
+    margin: 0 0 16px 0;
+    font-size: 0.875rem;
+    color: #718096;
+}
+
+.wizard-session-label {
+    margin: 0 0 16px 0;
+    padding: 10px 14px;
+    background: #f8f9fa;
+    border-radius: 8px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.set-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.set-row {
+    border: 1px solid #e8eaed;
+    border-radius: 10px;
+    padding: 14px;
+    background: #fdfdfe;
+}
+
+.set-row-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 10px;
+}
+
+.set-row-number {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #718096;
+}
+
+.set-row-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.popup-form .set-row-actions button {
+    padding: 4px 10px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: white;
+    color: #5a6c7d;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    width: auto;
+}
+
+.popup-form .set-row-actions button:hover:not(:disabled) {
+    border-color: #667eea;
+    color: #667eea;
+    transform: none;
+}
+
+.set-row-fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 10px;
+    align-items: end;
+}
+
+.set-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin: 0;
+}
+
+.set-field > span {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: #a0aec0;
+}
+
+.popup-form .set-field input {
+    margin: 0;
+}
+
+.set-field-exercise {
+    grid-column: span 2;
+    min-width: 180px;
+}
+
+.set-field-notes {
+    grid-column: span 2;
+    min-width: 180px;
+}
+
+.popup-form .add-set-button {
+    width: 100%;
+    margin-top: 12px;
+    padding: 10px;
+    background: white;
+    color: #667eea;
+    border: 1px dashed #c3c9f5;
+    border-radius: 8px;
+    font-weight: 600;
+}
+
+.popup-form .add-set-button:hover {
+    background: #f4f5fb;
+    transform: none;
+}
+
+@media (max-width: 640px) {
+    .set-field-exercise,
+    .set-field-notes {
+        grid-column: 1 / -1;
+    }
+}

--- a/src/components/go_heavier/LogWorkoutWizard.tsx
+++ b/src/components/go_heavier/LogWorkoutWizard.tsx
@@ -1,0 +1,447 @@
+import React from "react"
+
+import { API_URL } from "../../configs"
+import ExercisePicker, { PickableExercise } from "./ExercisePicker"
+import {
+    MAX_WORKOUTS_PER_REQUEST,
+    SetRow,
+    buildPayloads,
+    chunk,
+    countByExercise,
+    emptyRow,
+    nowForInput,
+    setIndexes,
+    toInstant,
+    validateRows
+} from "./logWorkout"
+import "./LocationForm.css"
+import "./LogWorkoutWizard.css"
+
+interface Props {
+    onClose: () => void
+    onSaved: (sessionId: string) => void
+    // Supplied when adding to a session that already exists, which skips step one.
+    session?: { id: string; label: string }
+}
+
+interface State {
+    step: "session" | "sets"
+    locations: any[]
+    exercises: PickableExercise[]
+    locationId: string
+    workoutTime: string
+    sessionId: string | null
+    sessionLabel: string
+    rows: SetRow[]
+    // Sets the session already holds, per exercise, so numbering continues.
+    alreadyLogged: Record<string, number>
+    loading: boolean
+    error: string | null
+}
+
+export default class LogWorkoutWizard extends React.Component<Props, State> {
+    private nextKey = 0
+
+    constructor(props: Props) {
+        super(props)
+
+        const existing = props.session
+        this.nextKey = 1
+
+        this.state = {
+            step: existing ? "sets" : "session",
+            locations: [],
+            exercises: [],
+            locationId: "",
+            workoutTime: nowForInput(new Date()),
+            sessionId: existing ? existing.id : null,
+            sessionLabel: existing ? existing.label : "",
+            rows: existing ? [emptyRow("row-1")] : [],
+            alreadyLogged: {},
+            loading: false,
+            error: null
+        }
+    }
+
+    componentDidMount() {
+        this.fetchOptions()
+
+        if (this.props.session) {
+            this.fetchExistingSets(this.props.session.id)
+        }
+    }
+
+    // Adding to a session that already has sets: pick up the numbering where it
+    // left off rather than starting a second "set 1" for the same exercise.
+    fetchExistingSets = async (sessionId: string) => {
+        try {
+            const response = await fetch(`${API_URL}/go-heavier/workouts?session_id=${sessionId}`)
+            if (!response.ok) {
+                throw new Error("Failed to load the session's sets")
+            }
+            const sets = await response.json()
+            this.setState({ alreadyLogged: countByExercise(sets) })
+        } catch (error) {
+            console.error("Error loading existing sets:", error)
+            this.setState({ error: (error as Error).message })
+        }
+    }
+
+    makeKey = (): string => {
+        this.nextKey += 1
+        return `row-${this.nextKey}`
+    }
+
+    fetchOptions = async () => {
+        try {
+            const [locationsRes, exercisesRes] = await Promise.all([
+                fetch(`${API_URL}/go-heavier/locations`),
+                fetch(`${API_URL}/go-heavier/exercises`)
+            ])
+
+            if (!locationsRes.ok || !exercisesRes.ok) {
+                throw new Error("Failed to load locations and exercises")
+            }
+
+            const locations = await locationsRes.json()
+            const exercises = await exercisesRes.json()
+
+            this.setState({
+                locations,
+                exercises,
+                locationId: locations.length > 0 ? locations[0].id : ""
+            })
+        } catch (error) {
+            console.error("Error loading form options:", error)
+            this.setState({ error: (error as Error).message })
+        }
+    }
+
+    // Step one: the session has to exist before any set can point at it.
+    handleCreateSession = async (e: React.FormEvent) => {
+        e.preventDefault()
+        this.setState({ error: null })
+
+        if (!this.state.locationId) {
+            this.setState({ error: "Pick where you trained" })
+            return
+        }
+
+        if (!this.state.workoutTime) {
+            this.setState({ error: "Pick when you trained" })
+            return
+        }
+
+        this.setState({ loading: true })
+        try {
+            const response = await fetch(`${API_URL}/go-heavier/sessions`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    location_id: this.state.locationId,
+                    workout_time: toInstant(this.state.workoutTime)
+                })
+            })
+
+            if (!response.ok) {
+                throw new Error("Failed to create the session")
+            }
+
+            const session = await response.json()
+            const when = new Date(session.workout_time).toLocaleString("en-US", {
+                weekday: "short",
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit"
+            })
+
+            this.setState({
+                step: "sets",
+                sessionId: session.id,
+                sessionLabel: `${when} · ${session.location}`,
+                rows: [emptyRow(this.makeKey())],
+                loading: false
+            })
+        } catch (error) {
+            this.setState({ error: (error as Error).message, loading: false })
+        }
+    }
+
+    updateRow = (key: string, field: keyof Omit<SetRow, "key">, value: string) => {
+        this.setState(prev => ({
+            rows: prev.rows.map(row => (row.key === key ? { ...row, [field]: value } : row))
+        }))
+    }
+
+    addRow = () => {
+        this.setState(prev => {
+            // Carry the last exercise over: the next set is usually the same lift.
+            const last = prev.rows[prev.rows.length - 1]
+            return { rows: [...prev.rows, emptyRow(this.makeKey(), last ? last.exerciseId : "")] }
+        })
+    }
+
+    // The point of the copy button: another set of the same thing is one click.
+    duplicateRow = (key: string) => {
+        this.setState(prev => {
+            const position = prev.rows.findIndex(row => row.key === key)
+            if (position === -1) {
+                return null
+            }
+
+            const copy = { ...prev.rows[position], key: this.makeKey() }
+            const rows = [...prev.rows]
+            rows.splice(position + 1, 0, copy)
+            return { rows }
+        })
+    }
+
+    removeRow = (key: string) => {
+        this.setState(prev => ({ rows: prev.rows.filter(row => row.key !== key) }))
+    }
+
+    handleSubmitSets = async (e: React.FormEvent) => {
+        e.preventDefault()
+        this.setState({ error: null })
+
+        const problem = validateRows(this.state.rows)
+        if (problem) {
+            this.setState({ error: problem })
+            return
+        }
+
+        this.setState({ loading: true })
+        try {
+            const payloads = buildPayloads(this.state.rows, this.state.sessionId!, this.state.alreadyLogged)
+
+            // The endpoint takes ten sets at a time, so a long session goes up in
+            // batches rather than one oversized request.
+            for (const batch of chunk(payloads, MAX_WORKOUTS_PER_REQUEST)) {
+                const response = await fetch(`${API_URL}/go-heavier/workouts`, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ workouts: batch })
+                })
+
+                if (!response.ok) {
+                    throw new Error("Failed to save the sets")
+                }
+            }
+
+            this.props.onSaved(this.state.sessionId!)
+        } catch (error) {
+            this.setState({ error: (error as Error).message, loading: false })
+        }
+    }
+
+    renderSessionStep(): React.ReactNode {
+        return (
+            <form onSubmit={this.handleCreateSession}>
+                <p className="wizard-hint">
+                    Start with where and when. Sets get added once the session exists.
+                </p>
+
+                <label>
+                    Location: <span className="required">*</span>
+                    <select
+                        value={this.state.locationId}
+                        onChange={(e) => this.setState({ locationId: e.target.value })}
+                        required
+                    >
+                        <option value="">Select location...</option>
+                        {this.state.locations.map(location => (
+                            <option key={location.id} value={location.id}>
+                                {location.name}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+
+                <label>
+                    Time: <span className="required">*</span>
+                    <input
+                        type="datetime-local"
+                        value={this.state.workoutTime}
+                        onChange={(e) => this.setState({ workoutTime: e.target.value })}
+                        required
+                    />
+                </label>
+
+                {this.state.error && <p className="error-message">{this.state.error}</p>}
+
+                <div className="form-actions">
+                    <button type="submit" disabled={this.state.loading}>
+                        {this.state.loading ? "Starting..." : "Start session"}
+                    </button>
+                    <button type="button" onClick={this.props.onClose}>
+                        Cancel
+                    </button>
+                </div>
+            </form>
+        )
+    }
+
+    renderSetsStep(): React.ReactNode {
+        const indexes = setIndexes(this.state.rows, this.state.alreadyLogged)
+        const batches = chunk(this.state.rows, MAX_WORKOUTS_PER_REQUEST).length
+
+        return (
+            <form onSubmit={this.handleSubmitSets}>
+                <p className="wizard-session-label">📍 {this.state.sessionLabel}</p>
+
+                <div className="set-rows">
+                    {this.state.rows.map((row, position) => (
+                        <div key={row.key} className="set-row">
+                            <div className="set-row-head">
+                                <span className="set-row-number">Set {indexes[position]}</span>
+                                <div className="set-row-actions">
+                                    <button
+                                        type="button"
+                                        onClick={() => this.duplicateRow(row.key)}
+                                        title="Copy this set"
+                                    >
+                                        ⧉ Copy
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => this.removeRow(row.key)}
+                                        title="Remove this set"
+                                        disabled={this.state.rows.length === 1}
+                                    >
+                                        ✖
+                                    </button>
+                                </div>
+                            </div>
+
+                            <div className="set-row-fields">
+                                <label className="set-field set-field-exercise">
+                                    <span>Exercise</span>
+                                    <ExercisePicker
+                                        exercises={this.state.exercises}
+                                        value={row.exerciseId}
+                                        onChange={(id) => this.updateRow(row.key, "exerciseId", id)}
+                                        label={`Exercise for set ${position + 1}`}
+                                    />
+                                </label>
+
+                                <label className="set-field">
+                                    <span>Reps</span>
+                                    <input
+                                        type="number"
+                                        min="1"
+                                        max="99"
+                                        value={row.repetitions}
+                                        onChange={(e) => this.updateRow(row.key, "repetitions", e.target.value)}
+                                    />
+                                </label>
+
+                                <label className="set-field">
+                                    <span>Weight (kg)</span>
+                                    <input
+                                        type="number"
+                                        step="0.1"
+                                        value={row.weightKg}
+                                        onChange={(e) => this.updateRow(row.key, "weightKg", e.target.value)}
+                                    />
+                                </label>
+
+                                <label className="set-field">
+                                    <span>Bar (kg)</span>
+                                    <input
+                                        type="number"
+                                        step="0.1"
+                                        placeholder="—"
+                                        value={row.barWeightKg}
+                                        onChange={(e) => this.updateRow(row.key, "barWeightKg", e.target.value)}
+                                    />
+                                </label>
+
+                                <label className="set-field">
+                                    <span>Extra (kg)</span>
+                                    <input
+                                        type="number"
+                                        step="0.1"
+                                        placeholder="—"
+                                        value={row.supplementaryWeightKg}
+                                        onChange={(e) =>
+                                            this.updateRow(row.key, "supplementaryWeightKg", e.target.value)
+                                        }
+                                    />
+                                </label>
+
+                                <label className="set-field set-field-notes">
+                                    <span>Notes</span>
+                                    <input
+                                        type="text"
+                                        maxLength={512}
+                                        placeholder="Optional"
+                                        value={row.notes}
+                                        onChange={(e) => this.updateRow(row.key, "notes", e.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                <button type="button" className="add-set-button" onClick={this.addRow}>
+                    ➕ Add another set
+                </button>
+
+                {this.state.error && <p className="error-message">{this.state.error}</p>}
+
+                <div className="form-actions">
+                    <button type="submit" disabled={this.state.loading}>
+                        {this.state.loading
+                            ? "Saving..."
+                            : `Save ${this.state.rows.length} ${this.state.rows.length === 1 ? "set" : "sets"}`}
+                    </button>
+                    <button type="button" onClick={this.props.onClose}>
+                        Done for now
+                    </button>
+                </div>
+
+                {batches > 1 && (
+                    <p className="wizard-hint">
+                        Saving in {batches} batches: the API takes {MAX_WORKOUTS_PER_REQUEST} sets at a time.
+                    </p>
+                )}
+            </form>
+        )
+    }
+
+    render(): React.ReactNode {
+        return (
+            <div className="popup-overlay" onClick={this.props.onClose}>
+                <div
+                    className="popup-form log-workout-wizard"
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <button className="close-button" onClick={this.props.onClose}>
+                        ✖
+                    </button>
+
+                    <h2>
+                        {this.props.session
+                            ? "Add sets"
+                            : this.state.step === "session"
+                                ? "New session"
+                                : "Log your sets"}
+                    </h2>
+
+                    {!this.props.session && (
+                        <ol className="wizard-steps">
+                            <li className={this.state.step === "session" ? "current" : "done"}>
+                                1. Session
+                            </li>
+                            <li className={this.state.step === "sets" ? "current" : ""}>2. Sets</li>
+                        </ol>
+                    )}
+
+                    {this.state.step === "session" ? this.renderSessionStep() : this.renderSetsStep()}
+                </div>
+            </div>
+        )
+    }
+}

--- a/src/components/go_heavier/logWorkout.test.ts
+++ b/src/components/go_heavier/logWorkout.test.ts
@@ -1,0 +1,214 @@
+import {
+    MAX_WORKOUTS_PER_REQUEST,
+    SetRow,
+    buildPayloads,
+    chunk,
+    countByExercise,
+    emptyRow,
+    filterExercises,
+    nowForInput,
+    setIndexes,
+    toInstant,
+    validateRows
+} from "./logWorkout"
+
+function row(overrides: Partial<SetRow> = {}): SetRow {
+    return { ...emptyRow("k", "ex-1"), weightKg: "40", ...overrides }
+}
+
+describe("setIndexes", () => {
+    // A set's index counts within its own exercise, which is how the API stores it.
+    it("counts within each exercise, not across the session", () => {
+        const rows = [
+            row({ key: "a", exerciseId: "bench" }),
+            row({ key: "b", exerciseId: "bench" }),
+            row({ key: "c", exerciseId: "squat" }),
+            row({ key: "d", exerciseId: "bench" })
+        ]
+
+        expect(setIndexes(rows)).toEqual([1, 2, 1, 3])
+    })
+
+    it("handles an empty list", () => {
+        expect(setIndexes([])).toEqual([])
+    })
+
+    // Adding to a session that already has sets must not start a second "set 1".
+    it("carries on from what the session already holds", () => {
+        const rows = [
+            row({ key: "a", exerciseId: "bench" }),
+            row({ key: "b", exerciseId: "squat" }),
+            row({ key: "c", exerciseId: "bench" })
+        ]
+
+        expect(setIndexes(rows, { bench: 3 })).toEqual([4, 1, 5])
+    })
+})
+
+describe("countByExercise", () => {
+    it("counts the sets logged per exercise", () => {
+        expect(
+            countByExercise([
+                { exercise_id: "bench" },
+                { exercise_id: "squat" },
+                { exercise_id: "bench" }
+            ])
+        ).toEqual({ bench: 2, squat: 1 })
+    })
+
+    it("returns nothing for an empty session", () => {
+        expect(countByExercise([])).toEqual({})
+    })
+})
+
+describe("chunk", () => {
+    it("splits into batches of the given size", () => {
+        expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+    })
+
+    it("keeps a short list in one batch", () => {
+        expect(chunk([1, 2], 10)).toEqual([[1, 2]])
+    })
+
+    it("returns nothing for an empty list", () => {
+        expect(chunk([], 10)).toEqual([])
+    })
+
+    // The endpoint accepts at most ten sets per request.
+    it("never exceeds the request limit", () => {
+        const rows = Array.from({ length: 23 }, (_, i) => i)
+        const batches = chunk(rows, MAX_WORKOUTS_PER_REQUEST)
+
+        expect(batches).toHaveLength(3)
+        batches.forEach(batch => expect(batch.length).toBeLessThanOrEqual(MAX_WORKOUTS_PER_REQUEST))
+        expect(batches.flat()).toEqual(rows)
+    })
+})
+
+describe("filterExercises", () => {
+    const exercises = [
+        { name: "Overhead Press" },
+        { name: "Bench Press" },
+        { name: "Hanging Knee Raise" }
+    ]
+
+    it("returns everything for an empty query", () => {
+        expect(filterExercises(exercises, "")).toHaveLength(3)
+        expect(filterExercises(exercises, "   ")).toHaveLength(3)
+    })
+
+    it("matches case insensitively on part of a word", () => {
+        expect(filterExercises(exercises, "bench")).toEqual([{ name: "Bench Press" }])
+        expect(filterExercises(exercises, "KNEE")).toEqual([{ name: "Hanging Knee Raise" }])
+    })
+
+    it("matches every term in any order", () => {
+        expect(filterExercises(exercises, "press over")).toEqual([{ name: "Overhead Press" }])
+    })
+
+    it("returns nothing when a term does not match", () => {
+        expect(filterExercises(exercises, "bench squat")).toEqual([])
+    })
+})
+
+describe("validateRows", () => {
+    it("accepts a well formed set", () => {
+        expect(validateRows([row()])).toBeNull()
+    })
+
+    it("insists on at least one set", () => {
+        expect(validateRows([])).toBe("Add at least one set")
+    })
+
+    it("insists on an exercise", () => {
+        expect(validateRows([row({ exerciseId: "" })])).toMatch(/pick an exercise/)
+    })
+
+    it("bounds repetitions", () => {
+        expect(validateRows([row({ repetitions: "0" })])).toMatch(/repetitions/)
+        expect(validateRows([row({ repetitions: "100" })])).toMatch(/repetitions/)
+        expect(validateRows([row({ repetitions: "8.5" })])).toMatch(/whole number/)
+    })
+
+    it("requires a weight but allows a negative one for assisted work", () => {
+        expect(validateRows([row({ weightKg: "" })])).toMatch(/weight/)
+        expect(validateRows([row({ weightKg: "-20" })])).toBeNull()
+        expect(validateRows([row({ weightKg: "1000" })])).toMatch(/weight/)
+    })
+
+    // The API rejects a bar weight of zero outright, which is why blank is the
+    // way to say "no bar".
+    it("allows a blank bar weight but not a zero one", () => {
+        expect(validateRows([row({ barWeightKg: "" })])).toBeNull()
+        expect(validateRows([row({ barWeightKg: "0" })])).toMatch(/bar weight/)
+        expect(validateRows([row({ barWeightKg: "20" })])).toBeNull()
+    })
+
+    it("allows a blank or negative supplementary weight", () => {
+        expect(validateRows([row({ supplementaryWeightKg: "" })])).toBeNull()
+        expect(validateRows([row({ supplementaryWeightKg: "-10" })])).toBeNull()
+        expect(validateRows([row({ supplementaryWeightKg: "100" })])).toMatch(/supplementary/)
+    })
+
+    it("names the offending set", () => {
+        expect(validateRows([row(), row({ key: "b", repetitions: "0" })])).toMatch(/^Set 2:/)
+    })
+})
+
+describe("buildPayloads", () => {
+    it("sends null rather than zero for absent optional values", () => {
+        const [payload] = buildPayloads([row()], "session-1")
+
+        expect(payload.bar_weight_kg).toBeNull()
+        expect(payload.supplementary_weight_kg).toBeNull()
+        expect(payload.notes).toBeNull()
+    })
+
+    it("keeps the values that were filled in", () => {
+        const [payload] = buildPayloads(
+            [row({ barWeightKg: "20", supplementaryWeightKg: "2.5", notes: "  felt strong  " })],
+            "session-1"
+        )
+
+        expect(payload.bar_weight_kg).toBe(20)
+        expect(payload.supplementary_weight_kg).toBe(2.5)
+        expect(payload.notes).toBe("felt strong")
+    })
+
+    it("continues the numbering when the session already has sets", () => {
+        const payloads = buildPayloads(
+            [row({ key: "a", exerciseId: "bench" }), row({ key: "b", exerciseId: "bench" })],
+            "session-1",
+            { bench: 2 }
+        )
+
+        expect(payloads.map(p => p.index)).toEqual([3, 4])
+    })
+
+    it("stamps the session and the per exercise index onto every set", () => {
+        const payloads = buildPayloads(
+            [row({ key: "a", exerciseId: "bench" }), row({ key: "b", exerciseId: "bench" })],
+            "session-1"
+        )
+
+        expect(payloads.map(p => p.session_id)).toEqual(["session-1", "session-1"])
+        expect(payloads.map(p => p.index)).toEqual([1, 2])
+    })
+})
+
+describe("toInstant", () => {
+    // The picker hands back local wall-clock time with no zone attached.
+    it("converts local wall clock time to a UTC instant", () => {
+        const local = "2026-08-22T18:30"
+        const instant = toInstant(local)
+
+        expect(instant).toBe(new Date(local).toISOString())
+        expect(new Date(instant).getHours()).toBe(18)
+    })
+})
+
+describe("nowForInput", () => {
+    it("formats for a datetime-local field", () => {
+        expect(nowForInput(new Date(2026, 7, 22, 9, 5))).toBe("2026-08-22T09:05")
+    })
+})

--- a/src/components/go_heavier/logWorkout.ts
+++ b/src/components/go_heavier/logWorkout.ts
@@ -1,0 +1,178 @@
+// The logic behind the log-a-workout popup, kept apart from the markup.
+
+export interface SetRow {
+    // Stable across reorders and duplication, so React keys stay put.
+    key: string
+    exerciseId: string
+    repetitions: string
+    weightKg: string
+    barWeightKg: string
+    supplementaryWeightKg: string
+    notes: string
+}
+
+export interface WorkoutPayload {
+    session_id: string
+    exercise_id: string
+    index: number
+    repetitions: number
+    weight_kg: number
+    bar_weight_kg: number | null
+    supplementary_weight_kg: number | null
+    notes: string | null
+}
+
+// The API takes at most ten sets per request.
+export const MAX_WORKOUTS_PER_REQUEST = 10
+
+export function emptyRow(key: string, exerciseId: string = ""): SetRow {
+    return {
+        key,
+        exerciseId,
+        repetitions: "10",
+        weightKg: "",
+        barWeightKg: "",
+        supplementaryWeightKg: "",
+        notes: ""
+    }
+}
+
+// How many sets a session already holds of each exercise, so added sets carry
+// on the numbering rather than restarting at one.
+export function countByExercise(sets: Array<{ exercise_id: string }>): Record<string, number> {
+    const counts: Record<string, number> = {}
+    sets.forEach(set => {
+        counts[set.exercise_id] = (counts[set.exercise_id] ?? 0) + 1
+    })
+    return counts
+}
+
+// A set's index counts within its own exercise, not across the session, so the
+// third row of bench press is index 3 even with other exercises interleaved.
+export function setIndexes(rows: SetRow[], alreadyLogged: Record<string, number> = {}): number[] {
+    const seen: Record<string, number> = { ...alreadyLogged }
+
+    return rows.map(row => {
+        const next = (seen[row.exerciseId] ?? 0) + 1
+        seen[row.exerciseId] = next
+        return next
+    })
+}
+
+export function chunk<T>(items: T[], size: number): T[][] {
+    if (size < 1) {
+        return [items]
+    }
+
+    const chunks: T[][] = []
+    for (let start = 0; start < items.length; start += size) {
+        chunks.push(items.slice(start, start + size))
+    }
+    return chunks
+}
+
+// Matches on every word typed, in any order, so "press over" finds
+// "Overhead Press".
+export function filterExercises<T extends { name: string }>(exercises: T[], query: string): T[] {
+    const terms = query.toLowerCase().split(/\s+/).filter(Boolean)
+    if (terms.length === 0) {
+        return exercises
+    }
+
+    return exercises.filter(exercise => {
+        const name = exercise.name.toLowerCase()
+        return terms.every(term => name.includes(term))
+    })
+}
+
+// Bounds mirror the API's, so a mistake reads as a message rather than a 422.
+export function validateRow(row: SetRow, position: number): string | null {
+    const label = `Set ${position + 1}`
+
+    if (!row.exerciseId) {
+        return `${label}: pick an exercise`
+    }
+
+    const repetitions = Number(row.repetitions)
+    if (!Number.isInteger(repetitions) || repetitions < 1 || repetitions > 99) {
+        return `${label}: repetitions must be a whole number between 1 and 99`
+    }
+
+    const weight = Number(row.weightKg)
+    if (row.weightKg.trim() === "" || Number.isNaN(weight) || weight <= -1000 || weight >= 1000) {
+        return `${label}: weight must be between -999 and 999 kg`
+    }
+
+    if (row.barWeightKg.trim() !== "") {
+        const bar = Number(row.barWeightKg)
+        // The API rejects a bar weight of zero outright; leave it blank instead.
+        if (Number.isNaN(bar) || bar <= 0 || bar >= 100) {
+            return `${label}: bar weight must be between 0 and 99 kg, or blank`
+        }
+    }
+
+    if (row.supplementaryWeightKg.trim() !== "") {
+        const supplementary = Number(row.supplementaryWeightKg)
+        if (Number.isNaN(supplementary) || supplementary <= -100 || supplementary >= 100) {
+            return `${label}: supplementary weight must be between -99 and 99 kg, or blank`
+        }
+    }
+
+    if (row.notes.length > 512) {
+        return `${label}: notes must be 512 characters or fewer`
+    }
+
+    return null
+}
+
+export function validateRows(rows: SetRow[]): string | null {
+    if (rows.length === 0) {
+        return "Add at least one set"
+    }
+
+    for (let position = 0; position < rows.length; position++) {
+        const problem = validateRow(rows[position], position)
+        if (problem) {
+            return problem
+        }
+    }
+
+    return null
+}
+
+// Blank optional weights go as null: the API takes null for "no bar", but
+// rejects a zero.
+function optionalNumber(value: string): number | null {
+    return value.trim() === "" ? null : Number(value)
+}
+
+export function buildPayloads(
+    rows: SetRow[],
+    sessionId: string,
+    alreadyLogged: Record<string, number> = {}
+): WorkoutPayload[] {
+    const indexes = setIndexes(rows, alreadyLogged)
+
+    return rows.map((row, position) => ({
+        session_id: sessionId,
+        exercise_id: row.exerciseId,
+        index: indexes[position],
+        repetitions: Number(row.repetitions),
+        weight_kg: Number(row.weightKg),
+        bar_weight_kg: optionalNumber(row.barWeightKg),
+        supplementary_weight_kg: optionalNumber(row.supplementaryWeightKg),
+        notes: row.notes.trim() ? row.notes.trim() : null
+    }))
+}
+
+// datetime-local hands back local wall-clock time with no zone; send the
+// instant it actually means.
+export function toInstant(localDateTime: string): string {
+    return new Date(localDateTime).toISOString()
+}
+
+export function nowForInput(now: Date): string {
+    const pad = (value: number) => String(value).padStart(2, "0")
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+        + `T${pad(now.getHours())}:${pad(now.getMinutes())}`
+}

--- a/src/pages/GoHeavier.css
+++ b/src/pages/GoHeavier.css
@@ -242,3 +242,31 @@ a.stat-card {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
+
+/* Log a workout call to action */
+.log-workout-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin: 0 auto 32px;
+    padding: 16px 32px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 50px;
+    font-size: 1.05rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.35);
+    transition: all 0.3s ease;
+}
+
+.log-workout-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 28px rgba(102, 126, 234, 0.45);
+}
+
+.log-workout-button .button-icon {
+    font-size: 1.2rem;
+}

--- a/src/pages/GoHeavier.tsx
+++ b/src/pages/GoHeavier.tsx
@@ -1,13 +1,19 @@
 import React from "react"
-import { Link } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 
 import { API_URL } from "../configs"
 import { fetchAllSessions } from "../components/go_heavier/sessions"
 import { formatCount, formatTonnes } from "../components/go_heavier/format"
 import GoHeavierNavBar from "../components/go_heavier/NavBar"
+import LogWorkoutWizard from "../components/go_heavier/LogWorkoutWizard"
 import "./GoHeavier.css"
 
+interface Props {
+    navigate: (path: string) => void
+}
+
 interface State {
+    showWizard: boolean
     loaded: boolean | null
     isRefreshing: boolean
     locationCount?: number
@@ -17,10 +23,11 @@ interface State {
     totalVolumeKg?: number
 }
 
-export default class GoHeavier extends React.Component<{}, State> {
-    constructor(props: {}) {
+export class GoHeavier extends React.Component<Props, State> {
+    constructor(props: Props) {
         super(props)
         this.state = {
+            showWizard: false,
             loaded: null,
             isRefreshing: false,
             locationCount: undefined,
@@ -129,6 +136,14 @@ export default class GoHeavier extends React.Component<{}, State> {
                                 </p>
                             </div>
 
+                            <button
+                                className="log-workout-button"
+                                onClick={() => this.setState({ showWizard: true })}
+                            >
+                                <span className="button-icon">🏋️</span>
+                                Log a workout
+                            </button>
+
                             <div className="stats-overview">
                                 <Link to="/go-heavier/locations" className="stat-card">
                                     <div className="stat-icon">📍</div>
@@ -172,6 +187,16 @@ export default class GoHeavier extends React.Component<{}, State> {
                                 </Link>
                             </div>
 
+                            {this.state.showWizard && (
+                                <LogWorkoutWizard
+                                    onClose={() => this.setState({ showWizard: false })}
+                                    onSaved={(sessionId) => {
+                                        this.setState({ showWizard: false })
+                                        this.props.navigate(`/go-heavier/sessions/${sessionId}`)
+                                    }}
+                                />
+                            )}
+
                             <div className="dashboard-footer">
                                 <p>Last refreshed: {new Date().toLocaleString()}</p>
                             </div>
@@ -181,4 +206,10 @@ export default class GoHeavier extends React.Component<{}, State> {
             </div>
         )
     }
+}
+
+// Wrapper component to use React Router hooks
+export default function GoHeavierWithNavigate() {
+    const navigate = useNavigate()
+    return <GoHeavier navigate={navigate} />
 }

--- a/src/pages/go_heavier/SessionDetail.tsx
+++ b/src/pages/go_heavier/SessionDetail.tsx
@@ -4,6 +4,8 @@ import { useNavigate, useParams } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import { API_URL, formatNotes } from "../../configs"
 import { formatCount, formatFullDateTime, formatWeight } from "../../components/go_heavier/format"
+import { SetRow, emptyRow, validateRow } from "../../components/go_heavier/logWorkout"
+import LogWorkoutWizard from "../../components/go_heavier/LogWorkoutWizard"
 import "../GoHeavier.css"
 import "../../components/go_heavier/Stats.css"
 import "./Sessions.css"
@@ -56,6 +58,17 @@ interface State {
     sets: WorkoutSet[] | null
     setsLoading: boolean
     setsError: string | null
+    // Only one exercise is editable at a time, keyed by its id.
+    editingExerciseId: string | null
+    drafts: Record<string, SetRow>
+    // Sets marked to be removed, applied on save so Cancel really cancels.
+    removing: Record<string, boolean>
+    savingEdit: boolean
+    editError: string | null
+    showAddSets: boolean
+    // The exercise queued for wholesale deletion, pending confirmation.
+    deleting: { exerciseId: string; name: string; sets: WorkoutSet[] } | null
+    deletingAll: boolean
 }
 
 class SessionDetailClass extends React.Component<Props, State> {
@@ -68,7 +81,15 @@ class SessionDetailClass extends React.Component<Props, State> {
             isRefreshing: false,
             sets: null,
             setsLoading: true,
-            setsError: null
+            setsError: null,
+            editingExerciseId: null,
+            drafts: {},
+            removing: {},
+            savingEdit: false,
+            editError: null,
+            showAddSets: false,
+            deleting: null,
+            deletingAll: false
         }
     }
 
@@ -116,6 +137,147 @@ class SessionDetailClass extends React.Component<Props, State> {
 
     handleBack = () => {
         this.props.navigate("/go-heavier/sessions")
+    }
+
+    startEdit = (exerciseId: string, sets: WorkoutSet[]) => {
+        const drafts: Record<string, SetRow> = {}
+
+        sets.forEach(set => {
+            drafts[set.id] = {
+                ...emptyRow(set.id, exerciseId),
+                repetitions: String(set.repetitions),
+                weightKg: String(set.weight_kg),
+                barWeightKg: set.bar_weight_kg === null ? "" : String(set.bar_weight_kg),
+                supplementaryWeightKg:
+                    set.supplementary_weight_kg === null ? "" : String(set.supplementary_weight_kg),
+                notes: set.notes ?? ""
+            }
+        })
+
+        this.setState({ editingExerciseId: exerciseId, drafts, removing: {}, editError: null })
+    }
+
+    cancelEdit = () => {
+        this.setState({ editingExerciseId: null, drafts: {}, removing: {}, editError: null })
+    }
+
+    askDeleteExercise = (exerciseId: string, name: string, sets: WorkoutSet[]) => {
+        this.setState({ deleting: { exerciseId, name, sets } })
+    }
+
+    cancelDeleteExercise = () => {
+        this.setState({ deleting: null })
+    }
+
+    confirmDeleteExercise = async () => {
+        const queued = this.state.deleting
+        if (!queued) {
+            return
+        }
+
+        this.setState({ deletingAll: true })
+        try {
+            for (const set of queued.sets) {
+                const response = await fetch(`${API_URL}/go-heavier/workouts/${set.id}`, {
+                    method: "DELETE"
+                })
+
+                if (!response.ok) {
+                    throw new Error("Failed to delete the sets")
+                }
+            }
+
+            this.setState({ deleting: null, deletingAll: false })
+            await Promise.all([this.fetchSession(), this.fetchSets()])
+        } catch (error) {
+            this.setState({ setsError: (error as Error).message, deleting: null, deletingAll: false })
+        }
+    }
+
+    removalCount = (sets: WorkoutSet[]): number =>
+        sets.filter(set => this.state.removing[set.id]).length
+
+    toggleRemoval = (setId: string) => {
+        this.setState(prev => ({
+            removing: { ...prev.removing, [setId]: !prev.removing[setId] },
+            editError: null
+        }))
+    }
+
+    updateDraft = (setId: string, field: keyof Omit<SetRow, "key">, value: string) => {
+        this.setState(prev => ({
+            drafts: { ...prev.drafts, [setId]: { ...prev.drafts[setId], [field]: value } }
+        }))
+    }
+
+    // Each set goes up as a whole workout: the API's update takes the full body.
+    saveEdit = async (sets: WorkoutSet[]) => {
+        this.setState({ editError: null })
+
+        // A set on its way out does not need to be valid.
+        const kept = sets.filter(set => !this.state.removing[set.id])
+        const doomed = sets.filter(set => this.state.removing[set.id])
+
+        for (let position = 0; position < kept.length; position++) {
+            const problem = validateRow(this.state.drafts[kept[position].id], position)
+            if (problem) {
+                this.setState({ editError: problem })
+                return
+            }
+
+            // The API treats null as "leave alone" on an update, and rejects a bar
+            // weight of zero, so there is no way to take one back off a set.
+            const set = kept[position]
+            if (set.bar_weight_kg !== null && this.state.drafts[set.id].barWeightKg.trim() === "") {
+                this.setState({
+                    editError: `Set ${set.index}: a bar weight cannot be removed once set. Delete the set and add it again instead.`
+                })
+                return
+            }
+        }
+
+        this.setState({ savingEdit: true })
+        try {
+            for (const set of doomed) {
+                const response = await fetch(`${API_URL}/go-heavier/workouts/${set.id}`, {
+                    method: "DELETE"
+                })
+
+                if (!response.ok) {
+                    throw new Error("Failed to delete the set")
+                }
+            }
+
+            for (const set of kept) {
+                const draft = this.state.drafts[set.id]
+                const response = await fetch(`${API_URL}/go-heavier/workouts/${set.id}`, {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        session_id: set.session_id,
+                        exercise_id: set.exercise_id,
+                        index: set.index,
+                        repetitions: Number(draft.repetitions),
+                        weight_kg: Number(draft.weightKg),
+                        bar_weight_kg: draft.barWeightKg.trim() === "" ? null : Number(draft.barWeightKg),
+                        // Zero and an empty string do clear these two; null would not.
+                        supplementary_weight_kg:
+                            draft.supplementaryWeightKg.trim() === "" ? 0 : Number(draft.supplementaryWeightKg),
+                        notes: draft.notes.trim()
+                    })
+                })
+
+                if (!response.ok) {
+                    throw new Error("Failed to save the changes")
+                }
+            }
+
+            this.setState({ editingExerciseId: null, drafts: {}, removing: {}, savingEdit: false })
+            // The session totals move with the sets, so reload both.
+            await Promise.all([this.fetchSession(), this.fetchSets()])
+        } catch (error) {
+            this.setState({ editError: (error as Error).message, savingEdit: false })
+        }
     }
 
     groupSetsByExercise = (): Array<{ exercise: SessionExerciseStats; sets: WorkoutSet[] }> => {
@@ -208,7 +370,16 @@ class SessionDetailClass extends React.Component<Props, State> {
                             </div>
 
                             <div className="detail-section stats-section">
-                                <h3>🏋️ Exercises</h3>
+                                <div className="section-head">
+                                    <h3>🏋️ Exercises</h3>
+                                    <button
+                                        type="button"
+                                        className="edit-set-button primary"
+                                        onClick={() => this.setState({ showAddSets: true })}
+                                    >
+                                        ➕ Add sets
+                                    </button>
+                                </div>
 
                                 {this.state.setsLoading && (
                                     <div className="detail-card">
@@ -228,6 +399,55 @@ class SessionDetailClass extends React.Component<Props, State> {
                                     </div>
                                 )}
 
+                                {this.state.deleting && (
+                                    <div className="popup-overlay" onClick={this.cancelDeleteExercise}>
+                                        <div className="confirm-dialog" onClick={(e) => e.stopPropagation()}>
+                                            <div className="confirm-header">
+                                                <h2>💪 Go Heavier</h2>
+                                            </div>
+                                            <div className="confirm-content">
+                                                <h3>Delete every set?</h3>
+                                                <p>
+                                                    This removes all {this.state.deleting.sets.length}{" "}
+                                                    {this.state.deleting.sets.length === 1 ? "set" : "sets"} of{" "}
+                                                    <strong>"{this.state.deleting.name}"</strong> from this session.
+                                                </p>
+                                                <p className="warning-text">This action cannot be undone.</p>
+                                            </div>
+                                            <div className="confirm-actions">
+                                                <button
+                                                    className="confirm-cancel-button"
+                                                    onClick={this.cancelDeleteExercise}
+                                                    disabled={this.state.deletingAll}
+                                                >
+                                                    Cancel
+                                                </button>
+                                                <button
+                                                    className="confirm-delete-button"
+                                                    onClick={this.confirmDeleteExercise}
+                                                    disabled={this.state.deletingAll}
+                                                >
+                                                    {this.state.deletingAll ? "Deleting..." : "Delete"}
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                )}
+
+                                {this.state.showAddSets && (
+                                    <LogWorkoutWizard
+                                        session={{
+                                            id: session.id,
+                                            label: `${formatFullDateTime(session.workout_time)} · ${session.location}`
+                                        }}
+                                        onClose={() => this.setState({ showAddSets: false })}
+                                        onSaved={() => {
+                                            this.setState({ showAddSets: false })
+                                            this.handleRefresh()
+                                        }}
+                                    />
+                                )}
+
                                 {!this.state.setsLoading && !this.state.setsError && grouped.map(({ exercise, sets }) => (
                                     <div key={exercise.exercise_id} className="detail-card session-exercise">
                                         <div className="session-exercise-head">
@@ -241,7 +461,56 @@ class SessionDetailClass extends React.Component<Props, State> {
                                                 {exercise.sets} sets · {formatCount(exercise.repetitions)} reps ·{" "}
                                                 {formatWeight(exercise.volume_kg)} · top {formatWeight(exercise.heaviest_weight_kg)}
                                             </span>
+                                            {this.state.editingExerciseId === exercise.exercise_id ? (
+                                                <span className="session-exercise-edit">
+                                                    <button
+                                                        type="button"
+                                                        className="edit-set-button primary"
+                                                        onClick={() => this.saveEdit(sets)}
+                                                        disabled={this.state.savingEdit}
+                                                    >
+                                                        {this.state.savingEdit
+                                                            ? "Saving..."
+                                                            : this.removalCount(sets) > 0
+                                                                ? `Save · delete ${this.removalCount(sets)}`
+                                                                : "Save"}
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        className="edit-set-button"
+                                                        onClick={this.cancelEdit}
+                                                        disabled={this.state.savingEdit}
+                                                    >
+                                                        Cancel
+                                                    </button>
+                                                </span>
+                                            ) : (
+                                                <span className="session-exercise-edit">
+                                                    <button
+                                                        type="button"
+                                                        className="edit-set-button"
+                                                        onClick={() => this.startEdit(exercise.exercise_id, sets)}
+                                                        disabled={this.state.editingExerciseId !== null}
+                                                        title={`Edit the ${exercise.name} sets`}
+                                                    >
+                                                        ✏️ Edit
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        className="edit-set-button danger"
+                                                        onClick={() => this.askDeleteExercise(exercise.exercise_id, exercise.name, sets)}
+                                                        disabled={this.state.editingExerciseId !== null}
+                                                        title={`Delete every ${exercise.name} set in this session`}
+                                                    >
+                                                        🗑️ Delete all
+                                                    </button>
+                                                </span>
+                                            )}
                                         </div>
+
+                                        {this.state.editingExerciseId === exercise.exercise_id && this.state.editError && (
+                                            <p className="error-message">{this.state.editError}</p>
+                                        )}
 
                                         <div className="set-table-wrapper">
                                             <table className="set-table">
@@ -254,10 +523,109 @@ class SessionDetailClass extends React.Component<Props, State> {
                                                         <th>Supp.</th>
                                                         <th>Total</th>
                                                         <th>Notes</th>
+                                                        {this.state.editingExerciseId === exercise.exercise_id && (
+                                                            <th><span className="visually-hidden">Delete</span></th>
+                                                        )}
                                                     </tr>
                                                 </thead>
                                                 <tbody>
                                                     {sets.map((set) => {
+                                                        const editing = this.state.editingExerciseId === exercise.exercise_id
+                                                        const draft = this.state.drafts[set.id]
+
+                                                        if (editing && this.state.removing[set.id]) {
+                                                            const total = set.weight_kg +
+                                                                (set.bar_weight_kg || 0) +
+                                                                (set.supplementary_weight_kg || 0)
+                                                            return (
+                                                                <tr key={set.id} className="set-row-removing">
+                                                                    <td>{set.index}</td>
+                                                                    <td>{set.repetitions}</td>
+                                                                    <td>{set.weight_kg.toFixed(1)}</td>
+                                                                    <td>{set.bar_weight_kg ? set.bar_weight_kg.toFixed(1) : "-"}</td>
+                                                                    <td>{set.supplementary_weight_kg ? set.supplementary_weight_kg.toFixed(1) : "-"}</td>
+                                                                    <td>{total.toFixed(1)}</td>
+                                                                    <td className="set-notes">{formatNotes(set.notes)}</td>
+                                                                    <td>
+                                                                        <button
+                                                                            type="button"
+                                                                            className="edit-set-button"
+                                                                            onClick={() => this.toggleRemoval(set.id)}
+                                                                            title={`Keep set ${set.index}`}
+                                                                        >
+                                                                            Undo
+                                                                        </button>
+                                                                    </td>
+                                                                </tr>
+                                                            )
+                                                        }
+
+                                                        if (editing && draft) {
+                                                            return (
+                                                                <tr key={set.id} className="set-row-editing">
+                                                                    <td>{set.index}</td>
+                                                                    <td>
+                                                                        <input
+                                                                            type="number"
+                                                                            aria-label={`Repetitions for set ${set.index}`}
+                                                                            value={draft.repetitions}
+                                                                            onChange={(e) => this.updateDraft(set.id, "repetitions", e.target.value)}
+                                                                        />
+                                                                    </td>
+                                                                    <td>
+                                                                        <input
+                                                                            type="number"
+                                                                            step="0.1"
+                                                                            aria-label={`Weight for set ${set.index}`}
+                                                                            value={draft.weightKg}
+                                                                            onChange={(e) => this.updateDraft(set.id, "weightKg", e.target.value)}
+                                                                        />
+                                                                    </td>
+                                                                    <td>
+                                                                        <input
+                                                                            type="number"
+                                                                            step="0.1"
+                                                                            placeholder="—"
+                                                                            aria-label={`Bar weight for set ${set.index}`}
+                                                                            value={draft.barWeightKg}
+                                                                            onChange={(e) => this.updateDraft(set.id, "barWeightKg", e.target.value)}
+                                                                        />
+                                                                    </td>
+                                                                    <td>
+                                                                        <input
+                                                                            type="number"
+                                                                            step="0.1"
+                                                                            placeholder="—"
+                                                                            aria-label={`Supplementary weight for set ${set.index}`}
+                                                                            value={draft.supplementaryWeightKg}
+                                                                            onChange={(e) => this.updateDraft(set.id, "supplementaryWeightKg", e.target.value)}
+                                                                        />
+                                                                    </td>
+                                                                    <td className="set-total-placeholder">—</td>
+                                                                    <td>
+                                                                        <input
+                                                                            type="text"
+                                                                            maxLength={512}
+                                                                            placeholder="Optional"
+                                                                            aria-label={`Notes for set ${set.index}`}
+                                                                            value={draft.notes}
+                                                                            onChange={(e) => this.updateDraft(set.id, "notes", e.target.value)}
+                                                                        />
+                                                                    </td>
+                                                                    <td>
+                                                                        <button
+                                                                            type="button"
+                                                                            className="edit-set-button"
+                                                                            onClick={() => this.toggleRemoval(set.id)}
+                                                                            title={`Delete set ${set.index}`}
+                                                                        >
+                                                                            🗑️
+                                                                        </button>
+                                                                    </td>
+                                                                </tr>
+                                                            )
+                                                        }
+
                                                         const total = set.weight_kg +
                                                             (set.bar_weight_kg || 0) +
                                                             (set.supplementary_weight_kg || 0)

--- a/src/pages/go_heavier/Sessions.css
+++ b/src/pages/go_heavier/Sessions.css
@@ -216,3 +216,112 @@
 .add-location-button .button-icon {
     font-size: 1.3rem;
 }
+
+/* Editing a session's sets, one exercise at a time */
+.session-exercise-edit {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.edit-set-button {
+    padding: 4px 12px;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #5a6c7d;
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.edit-set-button:hover:not(:disabled) {
+    border-color: #667eea;
+    color: #667eea;
+}
+
+.edit-set-button.primary {
+    background: #667eea;
+    border-color: #667eea;
+    color: white;
+}
+
+.edit-set-button.primary:hover:not(:disabled) {
+    background: #5568d3;
+    color: white;
+}
+
+.edit-set-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.set-row-editing td {
+    padding: 6px 8px;
+    vertical-align: middle;
+}
+
+.set-row-editing input {
+    width: 100%;
+    min-width: 64px;
+    padding: 6px 8px;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    font: inherit;
+    font-size: 0.875rem;
+    color: #2c3e50;
+}
+
+.set-row-editing input:focus {
+    outline: none;
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.12);
+}
+
+/* The total is derived, so it is only known once the change is saved. */
+.set-total-placeholder {
+    color: #a0aec0;
+}
+
+/* Section heading with an action alongside it */
+.section-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.section-head h3 {
+    margin: 0;
+}
+
+/* A set marked for deletion, applied when the edit is saved */
+.set-row-removing td {
+    color: #a0aec0;
+    text-decoration: line-through;
+    background: #fdf3f3;
+}
+
+.set-row-removing td:last-child {
+    text-decoration: none;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.edit-set-button.danger:hover:not(:disabled) {
+    border-color: #ef4444;
+    color: #ef4444;
+}


### PR DESCRIPTION
## Summary

Two commits: a popup for logging a whole gym session, and in-place editing of a session that already exists.

### `53ddf29` — Log a whole workout from one popup

A **Log a workout** button on the dashboard opens a two-step popup:

1. **Where and when** — creates the session, since a set can't exist without one to point at.
2. **A row per set** — exercise, reps, weight, bar, extra, notes.

The exercise field is a **searchable dropdown** that matches every word typed in any order, so `press over` finds *Overhead Press*. It works by keyboard (↑/↓, Enter, Escape) as well as mouse.

**Copy** duplicates a row in place — another set of the same lift at the same weight is the common case, and it's one click. **Add another set** carries the last exercise forward for the same reason.

Two things the form works out rather than asking for:

- **Set numbers.** A set's index counts within its own exercise, not across the session — bench, bench, squat, bench is 1, 2, 1, 3. It's derived from row order and shown read-only, so there's no way to typo a duplicate.
- **Batching.** `POST /workouts` takes at most 10 sets, so a longer session is split and the popup says how many batches.

### `df63643` — Edit, add and delete a session's sets in place

On a session page, each exercise gains:

- **✏️ Edit** — turns its table into inputs, saves each set back, then reloads so the header totals move with the change.
- **➕ Add sets** — reopens the same popup already pointed at this session, skipping step 1.
- **🗑️ Delete all** — clears an exercise from the session, behind a confirmation naming the exercise and the count.

Inside an edit, each set has a **bin that marks it** rather than removing it: the row goes struck-through with an Undo, Save reads "Save · delete 2", and Cancel genuinely cancels. Deletions and updates are applied together on save.

## Two API problems this surfaced

Neither is caused by this PR, and both shaped the code:

1. **Sets added to an existing session would have restarted numbering.** Adding to a session with three sets of an exercise produced a *second* set 1, 2, 3 — duplicate indexes, which the API accepts silently. The popup now counts what's already there and continues from it.

2. **`PUT /workouts/{id}` treats `null` as "leave unchanged".** You cannot clear an optional field through an update — verified: `notes: null` leaves the note, `bar_weight_kg: null` leaves the bar weight. An empty string clears notes and `0` clears supplementary weight, so the form sends those. **A bar weight has no escape at all** — `0` is rejected by the schema and `null` is ignored — so blanking one is refused with an explanatory message rather than silently doing nothing. Worth fixing server-side; the client workaround can then go.

## Testing

- **81 tests**, 27 of them new, covering the pure logic: per-exercise index derivation (including continuing from an existing session), batching against the 10-set cap, multi-term search, validation bounds mirroring the API's, null-vs-zero payload building, and local-time-to-UTC conversion.
- `tsc --noEmit` and `eslint` clean; `CI=true react-scripts build` compiles with no warnings.
- Exercised end to end against the dev API: session creation, a 12-set submission going up as 10 + 2 with correct per-exercise indexes, an edit round-trip with the session totals recalculating, adding a set to an existing session landing at index 4 with no duplicates, and delete-all taking a session from 9 sets / 3 exercises back to 6 / 2. Test data was removed afterwards.
- No browser tooling this session, so the popup has not been eyeballed — the six-field set row at narrow widths is the most likely thing to need tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)