### PR TITLE
Point production at the real API host

### DIFF
--- a/src/configs.ts
+++ b/src/configs.ts
@@ -1,4 +1,8 @@
-export const API_URL = process.env.API_URL || "http://localhost:8000"
+// Create React App only exposes variables prefixed with REACT_APP_, so reading
+// process.env.API_URL silently yielded undefined and every build fell back to
+// localhost — including the production one, which has the real host in
+// .env.production.
+export const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000"
 
 // Every workout page the app has fetched, written by the workouts page. The
 // suffix is bumped whenever the workout shape changes so a stale cache from an


### PR DESCRIPTION
## The bug

`src/configs.ts` read `process.env.API_URL`. Create React App only inlines variables prefixed with `REACT_APP_`, so that was always `undefined` and every build fell through to the hardcoded `http://localhost:8000` — **including the production one**, even though `.env.production` has held `https://api.thesammy2010.com` all along.

In development the fallback happens to be correct, which is why it went unnoticed. On the deployed site it meant every API request went to the *visitor's* own machine.

Confirmed in the compiled bundle before the fix:

```js
{…,REACT_APP_API_URL:"https://api.thesammy2010.com"}.API_URL||"http://localhost:8000"
```

The right value was sitting in the object, keyed under a name nothing read.

## The fix

One line: read `process.env.REACT_APP_API_URL`. After rebuilding, the production bundle contains `"https://api.thesammy2010.com"` and **zero** occurrences of the localhost fallback — the minifier folds it away once the left side is a literal.

## Testing

- `CI=true react-scripts build`, then grepped the emitted bundle for both hosts.
- 81 tests pass; `tsc --noEmit` and `eslint` clean.

## Note

This needs to land before the next deploy tag, otherwise the release ships a frontend that cannot reach its own API.

Separately, and not addressed here: every data endpoint on `https://api.thesammy2010.com` is currently returning **500** (`/go-heavier/locations`, `/exercises`, `/sessions`, `/workouts`), while `/openapi.json` serves fine and does include the session endpoints. The deployed API is up and on the current schema, but its data layer is failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)