### PR TITLE
Add Google Sign-In auth with role-based access control

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 REACT_APP_API_URL = "http://localhost:8000"
+REACT_APP_GOOGLE_CLIENT_ID = "904361218828-9iva1dgj3dce9eku248e3l71spa5ho3d.apps.googleusercontent.com"

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 REACT_APP_API_URL = "https://api.thesammy2010.com"
+REACT_APP_GOOGLE_CLIENT_ID = "904361218828-9iva1dgj3dce9eku248e3l71spa5ho3d.apps.googleusercontent.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "thesammy2010.com",
       "version": "1.3.0",
       "dependencies": {
+        "@react-oauth/google": "^0.13.5",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3004,6 +3005,16 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@remix-run/router": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://thesammy2010.com",
   "private": true,
   "dependencies": {
+    "@react-oauth/google": "^0.13.5",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>TheSammy2010</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      //
+      // GitHub Pages only serves static files, so a deep link like
+      // /go-heavier has no matching file and lands here instead of
+      // index.html. This rewrites the path into a query string and
+      // redirects to the real index.html, which index.html's own script
+      // then decodes back into the original URL via history.replaceState
+      // before React Router mounts - so the app never sees the redirect.
+      //
+      // Served from the domain root (custom domain, no repo-name path
+      // prefix to preserve), so pathSegmentsToKeep stays 0.
+      var pathSegmentsToKeep = 0;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + "//" + l.hostname + (l.port ? ":" + l.port : "") +
+        l.pathname.split("/").slice(0, 1 + pathSegmentsToKeep).join("/") + "/?/" +
+        l.pathname.slice(1).split("/").slice(pathSegmentsToKeep).join("/").replace(/&/g, "~and~") +
+        (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+        l.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,28 @@
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="%PUBLIC_URL%/icons/apple-touch-icon.png" />
     <link rel="manifest" type="application/json" href="%PUBLIC_URL%/manifest.json" />
     <title>TheSammy2010</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafgraph/spa-github-pages
+      //
+      // Undoes the redirect 404.html made: reads the real path back out of
+      // the query string it was packed into and replaces the URL with it
+      // via history.replaceState, before React Router mounts - so a deep
+      // link like /go-heavier ends up back on /go-heavier instead of
+      // staying on the "?/go-heavier" redirect target.
+      (function (l) {
+        if (l.search[1] === "/") {
+          var decoded = l.search.slice(1).split("&").map(function (s) {
+            return s.replace(/~and~/g, "&");
+          }).join("?");
+          window.history.replaceState(
+            null,
+            null,
+            l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      })(window.location);
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this website.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { GoogleOAuthProvider } from "@react-oauth/google"
 import "./App.css"
 
 import Footer from "./components/Footer"
@@ -17,10 +18,12 @@ import Sessions from "./pages/go_heavier/Sessions"
 import Stats from "./pages/go_heavier/Stats"
 import SessionDetail from "./pages/go_heavier/SessionDetail"
 import Workouts from "./pages/go_heavier/Workouts"
+import Admin from "./pages/Admin"
+import { GOOGLE_CLIENT_ID } from "./configs"
 
 const App: React.FC = () => {
     return (
-        <div>
+        <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
             <div>
                 <BrowserRouter>
                     <NavBar />
@@ -36,6 +39,7 @@ const App: React.FC = () => {
                         <Route path="/go-heavier/sessions/:id" element={<SessionDetail />} />
                         <Route path="/go-heavier/workouts" element={<Workouts />} />
                         <Route path="/about" element={<About />} />
+                        <Route path="/admin" element={<Admin />} />
                         <Route path="*" element={<NotFound />} />
                     </Routes>
                 </BrowserRouter>
@@ -43,7 +47,7 @@ const App: React.FC = () => {
             <div>
                 <Footer />
             </div>
-        </div>
+        </GoogleOAuthProvider>
     )
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,124 @@
+// Holds the signed-in user's Google ID token outside React state, so plain
+// functions (sessions.ts, logWorkout.ts, ...) can attach it to a request
+// without every caller threading it through as an argument. Components that
+// need to react to sign-in/sign-out use the useAuthToken hook below, which is
+// just a thin subscription over the same value.
+import { useEffect, useState } from "react"
+
+const TOKEN_KEY = "go-heavier-google-id-token"
+
+export interface GoogleProfile {
+    name: string
+    email: string
+    picture: string
+    // Seconds since epoch; the ID token is rejected by Google's verifier once
+    // this passes, so the UI treats it as signed-out slightly before then.
+    exp: number
+}
+
+type Listener = (token: string | null) => void
+
+let token: string | null = readStoredToken()
+const listeners = new Set<Listener>()
+
+function readStoredToken(): string | null {
+    try {
+        return localStorage.getItem(TOKEN_KEY)
+    } catch {
+        return null
+    }
+}
+
+// The ID token is a JWT; decoding the payload locally (no signature check) is
+// only ever used to read the expiry and profile fields for display, never to
+// authorize anything - the API is the one that verifies the signature.
+export function decodeProfile(idToken: string): GoogleProfile | null {
+    try {
+        const payload = idToken.split(".")[1]
+        const json = atob(payload.replace(/-/g, "+").replace(/_/g, "/"))
+        const claims = JSON.parse(decodeURIComponent(escape(json)))
+        return {
+            name: claims.name,
+            email: claims.email,
+            picture: claims.picture,
+            exp: claims.exp
+        }
+    } catch {
+        return null
+    }
+}
+
+export function isExpired(idToken: string): boolean {
+    const profile = decodeProfile(idToken)
+    if (!profile) {
+        return true
+    }
+    return Date.now() >= profile.exp * 1000
+}
+
+if (token && isExpired(token)) {
+    token = null
+    try {
+        localStorage.removeItem(TOKEN_KEY)
+    } catch {
+        // ignore
+    }
+}
+
+export function getToken(): string | null {
+    return token
+}
+
+export function setToken(next: string | null): void {
+    token = next
+    try {
+        if (next) {
+            localStorage.setItem(TOKEN_KEY, next)
+        } else {
+            localStorage.removeItem(TOKEN_KEY)
+        }
+    } catch {
+        // ignore - loss of persistence just means signing in again next visit
+    }
+    listeners.forEach(listener => listener(next))
+}
+
+export function signOut(): void {
+    setToken(null)
+}
+
+export function useAuthToken(): string | null {
+    const [current, setCurrent] = useState(token)
+
+    useEffect(() => {
+        listeners.add(setCurrent)
+        return () => {
+            listeners.delete(setCurrent)
+        }
+    }, [])
+
+    return current
+}
+
+// Lets non-React modules (roles.ts) react to sign-in/sign-out without going
+// through the hook. Returns an unsubscribe function.
+export function subscribeToken(listener: Listener): () => void {
+    listeners.add(listener)
+    return () => {
+        listeners.delete(listener)
+    }
+}
+
+// Drop-in replacement for fetch() against the API: attaches the signed-in
+// user's Google ID token so protected routes (require_viewer/require_editor)
+// see it, and is a no-op otherwise so signed-out callers behave exactly as
+// they did before auth existed.
+export function apiFetch(input: string, init: RequestInit = {}): Promise<Response> {
+    if (!token) {
+        return fetch(input, init)
+    }
+
+    const headers = new Headers(init.headers)
+    headers.set("Authorization", `Bearer ${token}`)
+    return fetch(input, { ...init, headers })
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Link, useLocation } from "react-router-dom"
 
+import { useIsAdmin } from "../roles"
 import "./NavBar.css"
 
 const LINKS = [
@@ -10,9 +11,12 @@ const LINKS = [
 
 export default function NavBar() {
     const location = useLocation()
+    const isAdmin = useIsAdmin()
 
     const isActive = (to: string) =>
         location.pathname === to || location.pathname.startsWith(`${to}/`)
+
+    const links = isAdmin ? [...LINKS, { to: "/admin", label: "🔧 Admin" }] : LINKS
 
     return (
         <nav className="site-navbar">
@@ -26,7 +30,7 @@ export default function NavBar() {
                 </Link>
 
                 <div className="site-navbar-links">
-                    {LINKS.map(link => (
+                    {links.map(link => (
                         <Link
                             key={link.to}
                             to={link.to}

--- a/src/components/go_heavier/ExerciseForm.tsx
+++ b/src/components/go_heavier/ExerciseForm.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import "./ExerciseForm.css"
-import { API_URL } from "../../configs"
+import { API_URL, ApiError } from "../../configs"
+import { apiFetch } from "../../auth"
 
 interface ExerciseFormProps {
     onClose: () => void
@@ -59,7 +60,7 @@ export default class ExerciseForm extends React.Component<ExerciseFormProps, Exe
         this.setState({ loading: true, error: null })
 
         try {
-            const response = await fetch(`${API_URL}/go-heavier/exercises`, {
+            const response = await apiFetch(`${API_URL}/go-heavier/exercises`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json"
@@ -68,7 +69,7 @@ export default class ExerciseForm extends React.Component<ExerciseFormProps, Exe
             })
 
             if (!response.ok) {
-                throw new Error("Failed to create exercise")
+                throw new ApiError(response.status, "Failed to create exercise")
             }
 
             const newExercise = await response.json()

--- a/src/components/go_heavier/LocationForm.tsx
+++ b/src/components/go_heavier/LocationForm.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import "./LocationForm.css"
 
-import { API_URL } from "../../configs"
+import { API_URL, ApiError } from "../../configs"
+import { apiFetch } from "../../auth"
 
 interface LocationFormProps {
     onClose: () => void // Function to close the popup
@@ -57,7 +58,7 @@ export default class LocationForm extends React.Component<LocationFormProps, Loc
         this.setState({ loading: true, error: null })
 
         try {
-            const response = await fetch(`${API_URL}/go-heavier/locations`, {
+            const response = await apiFetch(`${API_URL}/go-heavier/locations`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json"
@@ -66,7 +67,7 @@ export default class LocationForm extends React.Component<LocationFormProps, Loc
             })
 
             if (!response.ok) {
-                throw new Error("Failed to create location")
+                throw new ApiError(response.status, "Failed to create location")
             }
 
             const newLocation = await response.json()

--- a/src/components/go_heavier/LogWorkoutWizard.tsx
+++ b/src/components/go_heavier/LogWorkoutWizard.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 
-import { API_URL } from "../../configs"
+import { API_URL, ApiError } from "../../configs"
+import { apiFetch } from "../../auth"
 import ExercisePicker, { PickableExercise } from "./ExercisePicker"
 import {
     MAX_WORKOUTS_PER_REQUEST,
@@ -75,9 +76,9 @@ export default class LogWorkoutWizard extends React.Component<Props, State> {
     // left off rather than starting a second "set 1" for the same exercise.
     fetchExistingSets = async (sessionId: string) => {
         try {
-            const response = await fetch(`${API_URL}/go-heavier/workouts?session_id=${sessionId}`)
+            const response = await apiFetch(`${API_URL}/go-heavier/workouts?session_id=${sessionId}`)
             if (!response.ok) {
-                throw new Error("Failed to load the session's sets")
+                throw new ApiError(response.status, "Failed to load the session's sets")
             }
             const sets = await response.json()
             this.setState({ alreadyLogged: countByExercise(sets) })
@@ -95,12 +96,15 @@ export default class LogWorkoutWizard extends React.Component<Props, State> {
     fetchOptions = async () => {
         try {
             const [locationsRes, exercisesRes] = await Promise.all([
-                fetch(`${API_URL}/go-heavier/locations`),
-                fetch(`${API_URL}/go-heavier/exercises`)
+                apiFetch(`${API_URL}/go-heavier/locations`),
+                apiFetch(`${API_URL}/go-heavier/exercises`)
             ])
 
-            if (!locationsRes.ok || !exercisesRes.ok) {
-                throw new Error("Failed to load locations and exercises")
+            if (!locationsRes.ok) {
+                throw new ApiError(locationsRes.status, "Failed to load locations and exercises")
+            }
+            if (!exercisesRes.ok) {
+                throw new ApiError(exercisesRes.status, "Failed to load locations and exercises")
             }
 
             const locations = await locationsRes.json()
@@ -134,7 +138,7 @@ export default class LogWorkoutWizard extends React.Component<Props, State> {
 
         this.setState({ loading: true })
         try {
-            const response = await fetch(`${API_URL}/go-heavier/sessions`, {
+            const response = await apiFetch(`${API_URL}/go-heavier/sessions`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
@@ -144,7 +148,7 @@ export default class LogWorkoutWizard extends React.Component<Props, State> {
             })
 
             if (!response.ok) {
-                throw new Error("Failed to create the session")
+                throw new ApiError(response.status, "Failed to create the session")
             }
 
             const session = await response.json()
@@ -218,14 +222,14 @@ export default class LogWorkoutWizard extends React.Component<Props, State> {
             // The endpoint takes ten sets at a time, so a long session goes up in
             // batches rather than one oversized request.
             for (const batch of chunk(payloads, MAX_WORKOUTS_PER_REQUEST)) {
-                const response = await fetch(`${API_URL}/go-heavier/workouts`, {
+                const response = await apiFetch(`${API_URL}/go-heavier/workouts`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ workouts: batch })
                 })
 
                 if (!response.ok) {
-                    throw new Error("Failed to save the sets")
+                    throw new ApiError(response.status, "Failed to save the sets")
                 }
             }
 

--- a/src/components/go_heavier/NavBar.tsx
+++ b/src/components/go_heavier/NavBar.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from "react-router-dom"
+import SignIn from "./SignIn"
 import "./NavBar.css"
 
 export default function GoHeavierNavBar() {
@@ -39,13 +40,14 @@ export default function GoHeavierNavBar() {
                     >
                         📈 Stats
                     </Link>
-                    <Link 
-                        to="/go-heavier/workouts" 
+                    <Link
+                        to="/go-heavier/workouts"
                         className={location.pathname === "/go-heavier/workouts" ? "active" : ""}
                     >
                         📋 Workouts
                     </Link>
                 </nav>
+                <SignIn />
             </div>
         </div>
     )

--- a/src/components/go_heavier/SessionForm.tsx
+++ b/src/components/go_heavier/SessionForm.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 
-import { API_URL } from "../../configs"
+import { API_URL, ApiError } from "../../configs"
+import { apiFetch } from "../../auth"
 import { SessionSummary } from "./sessions"
 import "./LocationForm.css"
 
@@ -46,9 +47,9 @@ export default class SessionForm extends React.Component<Props, State> {
 
     fetchLocations = async () => {
         try {
-            const response = await fetch(`${API_URL}/go-heavier/locations`)
+            const response = await apiFetch(`${API_URL}/go-heavier/locations`)
             if (!response.ok) {
-                throw new Error("Failed to load locations")
+                throw new ApiError(response.status, "Failed to load locations")
             }
             const locations = await response.json()
             this.setState({
@@ -90,7 +91,7 @@ export default class SessionForm extends React.Component<Props, State> {
         this.setState({ loading: true })
 
         try {
-            const response = await fetch(`${API_URL}/go-heavier/sessions`, {
+            const response = await apiFetch(`${API_URL}/go-heavier/sessions`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json"
@@ -103,7 +104,7 @@ export default class SessionForm extends React.Component<Props, State> {
             })
 
             if (!response.ok) {
-                throw new Error("Failed to create session")
+                throw new ApiError(response.status, "Failed to create session")
             }
 
             const session = await response.json()

--- a/src/components/go_heavier/SignIn.css
+++ b/src/components/go_heavier/SignIn.css
@@ -1,0 +1,33 @@
+.go-heavier-signin {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: white;
+}
+
+.go-heavier-signin-profile {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.go-heavier-signin-profile img {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+}
+
+.go-heavier-signin-name {
+    font-size: 0.85rem;
+    color: inherit;
+}
+
+.go-heavier-signin-out {
+    background: none;
+    border: 1px solid currentColor;
+    border-radius: 4px;
+    padding: 0.2rem 0.6rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+    color: inherit;
+}

--- a/src/components/go_heavier/SignIn.tsx
+++ b/src/components/go_heavier/SignIn.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react"
+import { GoogleLogin, CredentialResponse } from "@react-oauth/google"
+
+import { API_URL } from "../../configs"
+import { apiFetch, decodeProfile, GoogleProfile, setToken, signOut, useAuthToken } from "../../auth"
+import "./SignIn.css"
+
+// A signed-in caller defaults to the "guest" role in the API until an admin
+// promotes them, so a fresh sign-in can still see 401/403s from protected
+// routes - that's expected, not a bug in this component.
+async function provisionUser(): Promise<void> {
+    try {
+        await apiFetch(`${API_URL}/users`, { method: "POST" })
+    } catch (error) {
+        console.error("Failed to provision user after sign-in", error)
+    }
+}
+
+export default function SignIn() {
+    const token = useAuthToken()
+    const [profile, setProfile] = useState<GoogleProfile | null>(null)
+
+    useEffect(() => {
+        setProfile(token ? decodeProfile(token) : null)
+    }, [token])
+
+    if (token && profile) {
+        return (
+            <div className="go-heavier-signin">
+                <div className="go-heavier-signin-profile">
+                    <img src={profile.picture} alt={profile.name} referrerPolicy="no-referrer" />
+                    <span className="go-heavier-signin-name">{profile.name}</span>
+                </div>
+                <button className="go-heavier-signin-out" onClick={signOut}>
+                    Sign out
+                </button>
+            </div>
+        )
+    }
+
+    return (
+        <div className="go-heavier-signin">
+            <GoogleLogin
+                onSuccess={(response: CredentialResponse) => {
+                    if (!response.credential) {
+                        return
+                    }
+                    setToken(response.credential)
+                    void provisionUser()
+                }}
+                onError={() => console.error("Google sign-in failed")}
+                useOneTap
+            />
+        </div>
+    )
+}

--- a/src/components/go_heavier/WorkoutForm.tsx
+++ b/src/components/go_heavier/WorkoutForm.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { API_URL } from "../../configs"
+import { API_URL, ApiError } from "../../configs"
+import { apiFetch } from "../../auth"
 import { SessionSummary, fetchAllSessions } from "./sessions"
 import "./ExerciseForm.css"
 
@@ -56,7 +57,7 @@ export default class WorkoutForm extends React.Component<Props, State> {
         try {
             const [sessions, exercisesRes] = await Promise.all([
                 fetchAllSessions(),
-                fetch(`${API_URL}/go-heavier/exercises`)
+                apiFetch(`${API_URL}/go-heavier/exercises`)
             ])
 
             const exercises = await exercisesRes.json()
@@ -167,7 +168,7 @@ export default class WorkoutForm extends React.Component<Props, State> {
         this.setState({ loading: true })
 
         try {
-            const response = await fetch(`${API_URL}/go-heavier/workouts`, {
+            const response = await apiFetch(`${API_URL}/go-heavier/workouts`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json"
@@ -176,7 +177,7 @@ export default class WorkoutForm extends React.Component<Props, State> {
             })
 
             if (!response.ok) {
-                throw new Error("Failed to create workout")
+                throw new ApiError(response.status, "Failed to create workout")
             }
 
             const result = await response.json()

--- a/src/components/go_heavier/sessions.ts
+++ b/src/components/go_heavier/sessions.ts
@@ -1,4 +1,5 @@
-import { API_URL } from "../../configs"
+import { API_URL, ApiError } from "../../configs"
+import { apiFetch } from "../../auth"
 
 // A session is one visit to a gym. Sets belong to a session, and the session
 // carries the location and the time — a set no longer carries either itself.
@@ -47,9 +48,9 @@ export interface SessionStats {
 export const SESSIONS_CACHE_KEY = "go-heavier-sessions"
 
 export async function fetchSessionStats(): Promise<SessionStats> {
-    const response = await fetch(`${API_URL}/go-heavier/sessions/stats`)
+    const response = await apiFetch(`${API_URL}/go-heavier/sessions/stats`)
     if (!response.ok) {
-        throw new Error("Failed to load session stats")
+        throw new ApiError(response.status, "Failed to load session stats")
     }
     return response.json()
 }
@@ -86,9 +87,9 @@ async function walkSessions(exerciseId?: string): Promise<SessionSummary[]> {
             params.set("exercise_id", exerciseId)
         }
 
-        const response = await fetch(`${API_URL}/go-heavier/sessions?${params}`)
+        const response = await apiFetch(`${API_URL}/go-heavier/sessions?${params}`)
         if (!response.ok) {
-            throw new Error("Failed to load sessions")
+            throw new ApiError(response.status, "Failed to load sessions")
         }
 
         const pageSessions: SessionSummary[] = await response.json()

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -4,6 +4,10 @@
 // .env.production.
 export const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000"
 
+// Google's OAuth client ID, matching GOOGLE_CLIENT_ID on the API. Not a
+// secret - it identifies the app to Google, it doesn't authenticate anything.
+export const GOOGLE_CLIENT_ID = process.env.REACT_APP_GOOGLE_CLIENT_ID || ""
+
 // Every workout page the app has fetched, written by the workouts page. The
 // suffix is bumped whenever the workout shape changes so a stale cache from an
 // older schema is ignored rather than rendered.
@@ -24,4 +28,20 @@ const TEXT_PLACEHOLDERS = new Set(["nan", "none", "null", "undefined"])
 export function formatNotes(notes?: string | null): string {
     const trimmed = (notes ?? "").trim()
     return TEXT_PLACEHOLDERS.has(trimmed.toLowerCase()) ? "" : trimmed
+}
+
+export const PERMISSION_DENIED_MESSAGE =
+    "You don't have permission to do this. Ask an admin to grant you a higher role."
+
+// Thrown after a !response.ok check so callers that already surface
+// error.message verbatim (most of this app's catch blocks) get a message
+// that tells a caller apart from a genuinely broken/unreachable API,
+// instead of both looking like "the server failed".
+export class ApiError extends Error {
+    status: number
+
+    constructor(status: number, fallbackMessage: string) {
+        super(status === 403 ? PERMISSION_DENIED_MESSAGE : fallbackMessage)
+        this.status = status
+    }
 }

--- a/src/pages/Admin.css
+++ b/src/pages/Admin.css
@@ -1,0 +1,47 @@
+/* Admin page. Every class is prefixed: stylesheets are bundled globally here,
+   so an unprefixed name would leak onto every other page. */
+
+.admin-page {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 48px 24px 64px;
+}
+
+.admin-hero {
+    text-align: center;
+    margin-bottom: 24px;
+}
+
+.admin-hero h1 {
+    margin: 0;
+    font-size: 2.25rem;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+    color: #2c3e50;
+}
+
+.admin-lead {
+    margin: 0;
+    font-size: 1.125rem;
+    line-height: 1.6;
+    color: #5a6c7d;
+    text-align: center;
+}
+
+.admin-restricted {
+    margin: 0;
+    font-size: 1.0625rem;
+    line-height: 1.6;
+    color: #c0392b;
+    text-align: center;
+}
+
+@media (max-width: 640px) {
+    .admin-page {
+        padding: 32px 16px 48px;
+    }
+
+    .admin-hero h1 {
+        font-size: 1.75rem;
+    }
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,0 +1,22 @@
+import { useIsAdmin } from "../roles"
+import "./Admin.css"
+
+// Root-level, not under /go-heavier: admin tools here are expected to reach
+// across the whole site, not just the go-heavier resources.
+export default function Admin() {
+    const isAdmin = useIsAdmin()
+
+    return (
+        <div className="admin-page">
+            <header className="admin-hero">
+                <h1>🔧 Admin</h1>
+            </header>
+
+            {isAdmin ? (
+                <p className="admin-lead">Admin tools live here. Nothing built yet.</p>
+            ) : (
+                <p className="admin-restricted">This page is restricted to admins.</p>
+            )}
+        </div>
+    )
+}

--- a/src/pages/GoHeavier.tsx
+++ b/src/pages/GoHeavier.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import { Link, useNavigate } from "react-router-dom"
 
-import { API_URL } from "../configs"
+import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../configs"
+import { apiFetch } from "../auth"
+import { canAccess, subscribeAccess, subscribeAccessReady } from "../roles"
 import { fetchAllSessions } from "../components/go_heavier/sessions"
 import { formatCount, formatTonnes } from "../components/go_heavier/format"
 import GoHeavierNavBar from "../components/go_heavier/NavBar"
@@ -15,6 +17,7 @@ interface Props {
 interface State {
     showWizard: boolean
     loaded: boolean | null
+    loadError: string | null
     isRefreshing: boolean
     locationCount?: number
     exerciseCount?: number
@@ -24,11 +27,15 @@ interface State {
 }
 
 export class GoHeavier extends React.Component<Props, State> {
+    unsubscribeAccess?: () => void
+    unsubscribeReady?: () => void
+
     constructor(props: Props) {
         super(props)
         this.state = {
             showWizard: false,
             loaded: null,
+            loadError: null,
             isRefreshing: false,
             locationCount: undefined,
             exerciseCount: undefined,
@@ -48,9 +55,16 @@ export class GoHeavier extends React.Component<Props, State> {
         try {
             const [sessions, locationsRes, exercisesRes] = await Promise.all([
                 fetchAllSessions(),
-                fetch(`${API_URL}/go-heavier/locations`),
-                fetch(`${API_URL}/go-heavier/exercises`)
+                apiFetch(`${API_URL}/go-heavier/locations`),
+                apiFetch(`${API_URL}/go-heavier/exercises`)
             ])
+
+            if (!locationsRes.ok) {
+                throw new ApiError(locationsRes.status, "Failed to load locations")
+            }
+            if (!exercisesRes.ok) {
+                throw new ApiError(exercisesRes.status, "Failed to load exercises")
+            }
 
             const locations = await locationsRes.json()
             const exercises = await exercisesRes.json()
@@ -62,6 +76,7 @@ export class GoHeavier extends React.Component<Props, State> {
             await waitOut()
             this.setState({
                 loaded: true,
+                loadError: null,
                 isRefreshing: false,
                 locationCount: locations.length,
                 exerciseCount: exercises.length,
@@ -72,12 +87,35 @@ export class GoHeavier extends React.Component<Props, State> {
         } catch (error) {
             console.error("Error fetching dashboard counts:", error)
             await waitOut()
-            this.setState({ loaded: false, isRefreshing: false })
+            this.setState({ loaded: false, loadError: (error as Error).message, isRefreshing: false })
         }
     }
 
-    componentDidMount() {
+    // Only skips the very first, automatic load - the refresh/retry buttons
+    // call fetchCounts directly and always hit the API, since clicking one
+    // is an explicit request that's worth trying even if we think it'll
+    // fail. All three underlying requests are needed for this page, so it's
+    // an all-or-nothing check.
+    autoFetch = () => {
+        const canAccessAll =
+            canAccess("GET", "/go-heavier/sessions") &&
+            canAccess("GET", "/go-heavier/locations") &&
+            canAccess("GET", "/go-heavier/exercises")
+        if (!canAccessAll) {
+            this.setState({ loaded: false, loadError: PERMISSION_DENIED_MESSAGE })
+            return
+        }
         this.fetchCounts()
+    }
+
+    componentDidMount() {
+        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
+    }
+
+    componentWillUnmount() {
+        this.unsubscribeAccess?.()
+        this.unsubscribeReady?.()
     }
 
     handleRefresh = () => {
@@ -113,7 +151,9 @@ export class GoHeavier extends React.Component<Props, State> {
                     {this.state.loaded === false && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Dashboard</h2>
-                            <p className="error-message">Unable to fetch data from server</p>
+                            <p className="error-message">
+                                {this.state.loadError ?? "Unable to fetch data from server"}
+                            </p>
                             <button onClick={this.handleRetry} disabled={this.state.isRefreshing}>
                                 {this.state.isRefreshing ? (
                                     <>
@@ -136,13 +176,15 @@ export class GoHeavier extends React.Component<Props, State> {
                                 </p>
                             </div>
 
-                            <button
-                                className="log-workout-button"
-                                onClick={() => this.setState({ showWizard: true })}
-                            >
-                                <span className="button-icon">🏋️</span>
-                                Log a workout
-                            </button>
+                            {canAccess("POST", "/go-heavier/sessions") && canAccess("POST", "/go-heavier/workouts") && (
+                                <button
+                                    className="log-workout-button"
+                                    onClick={() => this.setState({ showWizard: true })}
+                                >
+                                    <span className="button-icon">🏋️</span>
+                                    Log a workout
+                                </button>
+                            )}
 
                             <div className="stats-overview">
                                 <Link to="/go-heavier/locations" className="stat-card">

--- a/src/pages/go_heavier/ExerciseDetail.tsx
+++ b/src/pages/go_heavier/ExerciseDetail.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
-import { API_URL, formatNotes } from "../../configs"
+import { API_URL, ApiError, formatNotes } from "../../configs"
+import { apiFetch } from "../../auth"
+import { canAccess, subscribeAccess } from "../../roles"
 import { formatCount, formatFullDate, formatLongDate, formatWeight } from "../../components/go_heavier/format"
 import { SessionSummary, fetchAllSessions, indexSessions } from "../../components/go_heavier/sessions"
 import "../../components/go_heavier/Stats.css"
@@ -91,6 +93,8 @@ interface State {
 }
 
 class ExerciseDetailClass extends React.Component<{ id: string; navigate: any }, State> {
+    unsubscribeAccess?: () => void
+
     constructor(props: { id: string; navigate: any }) {
         super(props)
         this.state = {
@@ -126,6 +130,11 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
         this.fetchExercise()
         this.fetchStats()
         this.fetchExerciseSets()
+        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+    }
+
+    componentWillUnmount() {
+        this.unsubscribeAccess?.()
     }
 
     // Sets for this exercise, plus the sessions they belong to — a set carries
@@ -158,9 +167,9 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
                 exercise_id: this.props.id,
                 page: String(page)
             })
-            const response = await fetch(`${API_URL}/go-heavier/workouts?${params}`)
+            const response = await apiFetch(`${API_URL}/go-heavier/workouts?${params}`)
             if (!response.ok) {
-                throw new Error("Failed to load workouts")
+                throw new ApiError(response.status, "Failed to load workouts")
             }
 
             const pageSets: WorkoutSet[] = await response.json()
@@ -177,9 +186,9 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
     fetchStats = async () => {
         this.setState({ statsLoading: true, statsError: null })
         try {
-            const response = await fetch(`${API_URL}/go-heavier/exercises/${this.props.id}/stats`)
+            const response = await apiFetch(`${API_URL}/go-heavier/exercises/${this.props.id}/stats`)
             if (!response.ok) {
-                throw new Error("Failed to load stats")
+                throw new ApiError(response.status, "Failed to load stats")
             }
             const stats = await response.json()
             this.setState({ stats, statsLoading: false })
@@ -192,9 +201,9 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
     fetchExercise = async () => {
         this.setState({ loading: true, error: null })
         try {
-            const response = await fetch(`${API_URL}/go-heavier/exercises/${this.props.id}`)
+            const response = await apiFetch(`${API_URL}/go-heavier/exercises/${this.props.id}`)
             if (!response.ok) {
-                throw new Error("Exercise not found")
+                throw new ApiError(response.status, "Exercise not found")
             }
             const result = await response.json()
             this.setState({ 
@@ -221,9 +230,9 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
         this.fetchStats()
         this.fetchExerciseSets()
         try {
-            const response = await fetch(`${API_URL}/go-heavier/exercises/${this.props.id}`)
+            const response = await apiFetch(`${API_URL}/go-heavier/exercises/${this.props.id}`)
             if (!response.ok) {
-                throw new Error("Exercise not found")
+                throw new ApiError(response.status, "Exercise not found")
             }
             const result = await response.json()
             setTimeout(() => {
@@ -251,7 +260,7 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
         if (!this.state.exercise) return
 
         try {
-            await fetch(`${API_URL}/go-heavier/exercises/${this.props.id}`, {
+            await apiFetch(`${API_URL}/go-heavier/exercises/${this.props.id}`, {
                 method: "DELETE"
             })
             sessionStorage.removeItem('go-heavier-exercises')
@@ -322,7 +331,7 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
         this.setState({ formLoading: true })
 
         try {
-            const response = await fetch(`${API_URL}/go-heavier/exercises/${this.props.id}`, {
+            const response = await apiFetch(`${API_URL}/go-heavier/exercises/${this.props.id}`, {
                 method: "PUT",
                 headers: {
                     "Content-Type": "application/json"
@@ -331,7 +340,7 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
             })
 
             if (!response.ok) {
-                throw new Error("Failed to update exercise")
+                throw new ApiError(response.status, "Failed to update exercise")
             }
 
             const result = await response.json()
@@ -603,17 +612,16 @@ class ExerciseDetailClass extends React.Component<{ id: string; navigate: any },
                                     <p className="exercise-detail-description">{this.state.exercise.description}</p>
                                 )}
                                 <div className="action-buttons">
-                                    <button className="edit-action-button" onClick={this.handleEdit}>
-                                        ✏️ Edit Exercise
-                                    </button>
-                                    <button
-                                        className="delete-action-button"
-                                        onClick={this.handleDelete}
-                                        disabled
-                                        title="Deleting is restricted to admins"
-                                    >
-                                        🗑️ Delete Exercise
-                                    </button>
+                                    {canAccess("PUT", `/go-heavier/exercises/${this.props.id}`) && (
+                                        <button className="edit-action-button" onClick={this.handleEdit}>
+                                            ✏️ Edit Exercise
+                                        </button>
+                                    )}
+                                    {canAccess("DELETE", `/go-heavier/exercises/${this.props.id}`) && (
+                                        <button className="delete-action-button" onClick={this.handleDelete}>
+                                            🗑️ Delete Exercise
+                                        </button>
+                                    )}
                                 </div>
                             </div>
 

--- a/src/pages/go_heavier/Exercises.tsx
+++ b/src/pages/go_heavier/Exercises.tsx
@@ -2,11 +2,15 @@ import React from "react"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import Exercise from "../../components/go_heavier/Exercise"
 import ExerciseForm from "../../components/go_heavier/ExerciseForm"
-import { API_URL } from "../../configs"
+import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../../configs"
+import { apiFetch } from "../../auth"
+import { canAccess, subscribeAccess, subscribeAccessReady } from "../../roles"
+import "../GoHeavier.css"
 import "./Exercises.css"
 
 interface State {
     configLoaded: boolean | null
+    loadError: string | null
     exercises?: any[]
     showForm?: boolean
     isRefreshing?: boolean
@@ -25,14 +29,23 @@ interface State {
 }
 
 export default class Exercises extends React.Component<{}, State> {
+    unsubscribeAccess?: () => void
+    unsubscribeReady?: () => void
+
     constructor(props: {}) {
         super(props)
         
+        // Guards against a cache written before an error response (e.g. a
+        // 403 body) was excluded from what gets cached - an old entry like
+        // that would otherwise be trusted as the exercise list forever,
+        // since it's truthy and never re-fetched.
         const cachedData = sessionStorage.getItem('go-heavier-exercises')
-        const cachedExercises = cachedData ? JSON.parse(cachedData) : undefined
+        const parsedExercises = cachedData ? JSON.parse(cachedData) : undefined
+        const cachedExercises = Array.isArray(parsedExercises) ? parsedExercises : undefined
         
         this.state = {
             configLoaded: cachedExercises ? true : null,
+            loadError: null,
             exercises: cachedExercises,
             showForm: false,
             isRefreshing: false,
@@ -58,29 +71,55 @@ export default class Exercises extends React.Component<{}, State> {
     handleRefresh = async () => {
         this.setState({ isRefreshing: true })
         try {
-            const response = await fetch(`${API_URL}/go-heavier/exercises`)
+            const response = await apiFetch(`${API_URL}/go-heavier/exercises`)
+            if (!response.ok) {
+                throw new ApiError(response.status, "Failed to load exercises")
+            }
             const result = await response.json()
-            
+
             sessionStorage.setItem('go-heavier-exercises', JSON.stringify(result))
-            
+
             setTimeout(() => {
-                this.setState({ 
-                    exercises: result, 
-                    configLoaded: true, 
+                this.setState({
+                    exercises: result,
+                    configLoaded: true,
+                    loadError: null,
                     isRefreshing: false,
-                    hasFetchedOnce: true 
+                    hasFetchedOnce: true
                 })
             }, 300)
         } catch (error) {
             console.error("Error fetching exercises:", error)
-            this.setState({ configLoaded: false, isRefreshing: false })
+            this.setState({ configLoaded: false, loadError: (error as Error).message, isRefreshing: false })
         }
     }
 
-    componentDidMount() {
-        if (!this.state.hasFetchedOnce) {
-            this.handleRefresh()
+    // Only skips the very first, automatic load - the refresh/retry buttons
+    // call handleRefresh directly and always hit the API, since clicking one
+    // is an explicit request that's worth trying even if we think it'll fail.
+    autoFetch = () => {
+        // Checked before the cache: an empty (but validly cached) list looks
+        // exactly like "already loaded, nothing to show" and would otherwise
+        // keep being trusted after a role change revoked access, silently
+        // masking the permission problem behind "No exercises found."
+        if (!canAccess("GET", "/go-heavier/exercises")) {
+            this.setState({ configLoaded: false, loadError: PERMISSION_DENIED_MESSAGE })
+            return
         }
+        if (this.state.hasFetchedOnce) {
+            return
+        }
+        this.handleRefresh()
+    }
+
+    componentDidMount() {
+        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
+    }
+
+    componentWillUnmount() {
+        this.unsubscribeAccess?.()
+        this.unsubscribeReady?.()
     }
 
     toggleFilter = (filterType: 'muscleGroups' | 'specificMuscles' | 'types' | 'equipments', value: string) => {
@@ -168,21 +207,6 @@ export default class Exercises extends React.Component<{}, State> {
         })
     }
 
-    showLoading() {
-        switch (this.state.configLoaded) {
-            case true:
-                return <></>
-            case false:
-                return <p className="error-message">Failed to load exercises</p>
-            default:
-                return (
-                    <div className="loading-spinner">
-                        <div className="spinner"></div>
-                    </div>
-                )
-        }
-    }
-
     render(): React.ReactNode {
         const filteredExercises = this.getFilteredExercises()
         const hasActiveFilters = this.state.filters.muscleGroups.length > 0 || 
@@ -204,12 +228,27 @@ export default class Exercises extends React.Component<{}, State> {
                             ↻
                         </button>
                     )}
-                    <div className="header">
-                        {this.showLoading()}
-                        {!this.state.configLoaded && this.state.configLoaded !== null && (
-                            <button onClick={this.handleRefresh}>Retry</button>
-                        )}
-                    </div>
+                    {this.state.configLoaded === null && (
+                        <div className="loading-spinner">
+                            <div className="spinner"></div>
+                        </div>
+                    )}
+                    {this.state.configLoaded === false && (
+                        <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
+                            <h2>Failed to Load Exercises</h2>
+                            <p className="error-message">
+                                {this.state.loadError ?? "Failed to load exercises"}
+                            </p>
+                            <button onClick={this.handleRefresh} disabled={this.state.isRefreshing}>
+                                {this.state.isRefreshing ? (
+                                    <>
+                                        <span className="button-spinner"></span>
+                                        Retrying...
+                                    </>
+                                ) : 'Retry'}
+                            </button>
+                        </div>
+                    )}
 
                     {this.state.configLoaded && this.state.exercises != null && (
                         <div className="filters-container">
@@ -342,8 +381,8 @@ export default class Exercises extends React.Component<{}, State> {
                             ))}
                         </div>
                     )}
-                    {this.state.configLoaded && (
-                        <button 
+                    {this.state.configLoaded && canAccess("POST", "/go-heavier/exercises") && (
+                        <button
                             className="add-location-button"
                             onClick={() => {
                                 this.setState({ showForm: true })

--- a/src/pages/go_heavier/LocationDetail.tsx
+++ b/src/pages/go_heavier/LocationDetail.tsx
@@ -1,7 +1,9 @@
 import React from "react"
 import { useParams, useNavigate } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
-import { API_URL, countryCodeToEmoji } from "../../configs"
+import { API_URL, ApiError, countryCodeToEmoji } from "../../configs"
+import { apiFetch } from "../../auth"
+import { canAccess, subscribeAccess } from "../../roles"
 import { formatCount, formatLongDate, formatWeight } from "../../components/go_heavier/format"
 import "../../components/go_heavier/Stats.css"
 import "./LocationDetail.css"
@@ -72,6 +74,8 @@ interface State {
 }
 
 class LocationDetailClass extends React.Component<{ id: string; navigate: any }, State> {
+    unsubscribeAccess?: () => void
+
     constructor(props: { id: string; navigate: any }) {
         super(props)
         this.state = {
@@ -102,14 +106,19 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
     componentDidMount() {
         this.fetchLocation()
         this.fetchStats()
+        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+    }
+
+    componentWillUnmount() {
+        this.unsubscribeAccess?.()
     }
 
     fetchStats = async () => {
         this.setState({ statsLoading: true, statsError: null })
         try {
-            const response = await fetch(`${API_URL}/go-heavier/locations/${this.props.id}/stats`)
+            const response = await apiFetch(`${API_URL}/go-heavier/locations/${this.props.id}/stats`)
             if (!response.ok) {
-                throw new Error("Failed to load stats")
+                throw new ApiError(response.status, "Failed to load stats")
             }
             const stats = await response.json()
             this.setState({ stats, statsLoading: false })
@@ -122,9 +131,9 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
     fetchLocation = async () => {
         this.setState({ loading: true, error: null })
         try {
-            const response = await fetch(`${API_URL}/go-heavier/locations/${this.props.id}`)
+            const response = await apiFetch(`${API_URL}/go-heavier/locations/${this.props.id}`)
             if (!response.ok) {
-                throw new Error("Location not found")
+                throw new ApiError(response.status, "Location not found")
             }
             const result = await response.json()
             this.setState({ 
@@ -151,9 +160,9 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
         this.setState({ isRefreshing: true })
         this.fetchStats()
         try {
-            const response = await fetch(`${API_URL}/go-heavier/locations/${this.props.id}`)
+            const response = await apiFetch(`${API_URL}/go-heavier/locations/${this.props.id}`)
             if (!response.ok) {
-                throw new Error("Location not found")
+                throw new ApiError(response.status, "Location not found")
             }
             const result = await response.json()
             setTimeout(() => {
@@ -181,7 +190,7 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
         if (!this.state.location) return
 
         try {
-            await fetch(`${API_URL}/go-heavier/locations/${this.props.id}`, {
+            await apiFetch(`${API_URL}/go-heavier/locations/${this.props.id}`, {
                 method: "DELETE"
             })
             // Clear cache and navigate back
@@ -280,7 +289,7 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
         this.setState({ formLoading: true })
 
         try {
-            const response = await fetch(`${API_URL}/go-heavier/locations/${this.props.id}`, {
+            const response = await apiFetch(`${API_URL}/go-heavier/locations/${this.props.id}`, {
                 method: "PUT",
                 headers: {
                     "Content-Type": "application/json"
@@ -289,7 +298,7 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
             })
 
             if (!response.ok) {
-                throw new Error("Failed to update location")
+                throw new ApiError(response.status, "Failed to update location")
             }
 
             const result = await response.json()
@@ -523,17 +532,16 @@ class LocationDetailClass extends React.Component<{ id: string; navigate: any },
                                 <h1>{this.state.location.name} {countryCodeToEmoji(this.state.location.address_country_iso3.substring(0, 2))}</h1>
                                 <p className="location-detail-description">{this.state.location.description}</p>
                                 <div className="action-buttons">
-                                    <button className="edit-action-button" onClick={this.handleEdit}>
-                                        ✏️ Edit Location
-                                    </button>
-                                    <button
-                                        className="delete-action-button"
-                                        onClick={this.handleDelete}
-                                        disabled
-                                        title="Deleting is restricted to admins"
-                                    >
-                                        🗑️ Delete Location
-                                    </button>
+                                    {canAccess("PUT", `/go-heavier/locations/${this.props.id}`) && (
+                                        <button className="edit-action-button" onClick={this.handleEdit}>
+                                            ✏️ Edit Location
+                                        </button>
+                                    )}
+                                    {canAccess("DELETE", `/go-heavier/locations/${this.props.id}`) && (
+                                        <button className="delete-action-button" onClick={this.handleDelete}>
+                                            🗑️ Delete Location
+                                        </button>
+                                    )}
                                 </div>
                             </div>
 

--- a/src/pages/go_heavier/Locations.tsx
+++ b/src/pages/go_heavier/Locations.tsx
@@ -1,13 +1,17 @@
 import React from "react"
 
-import { API_URL } from "../../configs"
+import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../../configs"
+import { apiFetch } from "../../auth"
+import { canAccess, subscribeAccess, subscribeAccessReady } from "../../roles"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import Location from "../../components/go_heavier/Location"
 import LocationForm from "../../components/go_heavier/LocationForm"
+import "../GoHeavier.css"
 import "./Locations.css"
 
 interface State {
     configLoaded: boolean | null
+    loadError: string | null
     locations?: any[]
     showForm?: boolean
     isRefreshing?: boolean
@@ -15,15 +19,24 @@ interface State {
 }
 
 export default class Locations extends React.Component<{}, State> {
+    unsubscribeAccess?: () => void
+    unsubscribeReady?: () => void
+
     constructor(props: {}) {
         super(props)
         
-        // Try to load cached data from sessionStorage
+        // Try to load cached data from sessionStorage. Guards against a
+        // cache written before an error response (e.g. a 403 body) was
+        // excluded from what gets cached - an old entry like that would
+        // otherwise be trusted as the location list forever, since it's
+        // truthy and never re-fetched.
         const cachedData = sessionStorage.getItem('go-heavier-locations')
-        const cachedLocations = cachedData ? JSON.parse(cachedData) : undefined
+        const parsedLocations = cachedData ? JSON.parse(cachedData) : undefined
+        const cachedLocations = Array.isArray(parsedLocations) ? parsedLocations : undefined
         
         this.state = {
             configLoaded: cachedLocations ? true : null,
+            loadError: null,
             locations: cachedLocations,
             showForm: false,
             isRefreshing: false,
@@ -34,47 +47,57 @@ export default class Locations extends React.Component<{}, State> {
     handleRefresh = async () => {
         this.setState({ isRefreshing: true })
         try {
-            const response = await fetch(`${API_URL}/go-heavier/locations`)
+            const response = await apiFetch(`${API_URL}/go-heavier/locations`)
+            if (!response.ok) {
+                throw new ApiError(response.status, "Failed to load locations")
+            }
             const result = await response.json()
-            
+
             // Cache the data
             sessionStorage.setItem('go-heavier-locations', JSON.stringify(result))
-            
+
             // Wait a bit for the fade animation
             setTimeout(() => {
-                this.setState({ 
-                    locations: result, 
-                    configLoaded: true, 
+                this.setState({
+                    locations: result,
+                    configLoaded: true,
+                    loadError: null,
                     isRefreshing: false,
-                    hasFetchedOnce: true 
+                    hasFetchedOnce: true
                 })
             }, 300)
         } catch (error) {
             console.error("Error fetching locations:", error)
-            this.setState({ configLoaded: false, isRefreshing: false })
+            this.setState({ configLoaded: false, loadError: (error as Error).message, isRefreshing: false })
         }
+    }
+
+    // Only skips the very first, automatic load - the refresh/retry buttons
+    // call handleRefresh directly and always hit the API, since clicking one
+    // is an explicit request that's worth trying even if we think it'll fail.
+    autoFetch = () => {
+        // Checked before the cache: an empty (but validly cached) list looks
+        // exactly like "already loaded, nothing to show" and would otherwise
+        // keep being trusted after a role change revoked access, silently
+        // masking the permission problem behind "No locations found."
+        if (!canAccess("GET", "/go-heavier/locations")) {
+            this.setState({ configLoaded: false, loadError: PERMISSION_DENIED_MESSAGE })
+            return
+        }
+        if (this.state.hasFetchedOnce) {
+            return
+        }
+        this.handleRefresh()
     }
 
     componentDidMount() {
-        // Only fetch if we haven't fetched before
-        if (!this.state.hasFetchedOnce) {
-            this.handleRefresh()
-        }
+        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
     }
 
-    showLoading() {
-        switch (this.state.configLoaded) {
-            case true:
-                return <></>
-            case false:
-                return <p className="error-message">Failed to load locations</p>
-            default:
-                return (
-                    <div className="loading-spinner">
-                        <div className="spinner"></div>
-                    </div>
-                )
-        }
+    componentWillUnmount() {
+        this.unsubscribeAccess?.()
+        this.unsubscribeReady?.()
     }
 
     render(): React.ReactNode {
@@ -93,12 +116,27 @@ export default class Locations extends React.Component<{}, State> {
                         ↻
                     </button>
                 )}
-                <div className="header">
-                    {this.showLoading()}
-                    {!this.state.configLoaded && this.state.configLoaded !== null && (
-                        <button onClick={this.handleRefresh}>Retry</button>
-                    )}
-                </div>
+                {this.state.configLoaded === null && (
+                    <div className="loading-spinner">
+                        <div className="spinner"></div>
+                    </div>
+                )}
+                {this.state.configLoaded === false && (
+                    <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
+                        <h2>Failed to Load Locations</h2>
+                        <p className="error-message">
+                            {this.state.loadError ?? "Failed to load locations"}
+                        </p>
+                        <button onClick={this.handleRefresh} disabled={this.state.isRefreshing}>
+                            {this.state.isRefreshing ? (
+                                <>
+                                    <span className="button-spinner"></span>
+                                    Retrying...
+                                </>
+                            ) : 'Retry'}
+                        </button>
+                    </div>
+                )}
                 {this.state.configLoaded && this.state.locations != null && this.state.locations.length === 0 && (
                     <div className="header">
                         <p>No locations found.</p>
@@ -111,8 +149,8 @@ export default class Locations extends React.Component<{}, State> {
                         ))}
                     </div>
                 )}
-                {this.state.configLoaded && (
-                    <button 
+                {this.state.configLoaded && canAccess("POST", "/go-heavier/locations") && (
+                    <button
                         className="add-location-button"
                         onClick={() => {
                             this.setState({ showForm: true })

--- a/src/pages/go_heavier/SessionDetail.tsx
+++ b/src/pages/go_heavier/SessionDetail.tsx
@@ -2,7 +2,9 @@ import React from "react"
 import { useNavigate, useParams } from "react-router-dom"
 
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
-import { API_URL, formatNotes } from "../../configs"
+import { API_URL, ApiError, formatNotes } from "../../configs"
+import { apiFetch } from "../../auth"
+import { canAccess, subscribeAccess } from "../../roles"
 import { formatCount, formatFullDateTime, formatWeight } from "../../components/go_heavier/format"
 import { SetRow, emptyRow, validateRow } from "../../components/go_heavier/logWorkout"
 import LogWorkoutWizard from "../../components/go_heavier/LogWorkoutWizard"
@@ -72,6 +74,8 @@ interface State {
 }
 
 class SessionDetailClass extends React.Component<Props, State> {
+    unsubscribeAccess?: () => void
+
     constructor(props: Props) {
         super(props)
         this.state = {
@@ -96,14 +100,19 @@ class SessionDetailClass extends React.Component<Props, State> {
     componentDidMount() {
         this.fetchSession()
         this.fetchSets()
+        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+    }
+
+    componentWillUnmount() {
+        this.unsubscribeAccess?.()
     }
 
     fetchSession = async () => {
         this.setState({ loading: true, error: null })
         try {
-            const response = await fetch(`${API_URL}/go-heavier/sessions/${this.props.id}`)
+            const response = await apiFetch(`${API_URL}/go-heavier/sessions/${this.props.id}`)
             if (!response.ok) {
-                throw new Error("Session not found")
+                throw new ApiError(response.status, "Session not found")
             }
             const session = await response.json()
             this.setState({ session, loading: false })
@@ -116,9 +125,9 @@ class SessionDetailClass extends React.Component<Props, State> {
     fetchSets = async () => {
         this.setState({ setsLoading: true, setsError: null })
         try {
-            const response = await fetch(`${API_URL}/go-heavier/workouts?session_id=${this.props.id}`)
+            const response = await apiFetch(`${API_URL}/go-heavier/workouts?session_id=${this.props.id}`)
             if (!response.ok) {
-                throw new Error("Failed to load the sets in this session")
+                throw new ApiError(response.status, "Failed to load the sets in this session")
             }
             const sets: WorkoutSet[] = await response.json()
             this.setState({ sets, setsLoading: false })
@@ -178,12 +187,12 @@ class SessionDetailClass extends React.Component<Props, State> {
         this.setState({ deletingAll: true })
         try {
             for (const set of queued.sets) {
-                const response = await fetch(`${API_URL}/go-heavier/workouts/${set.id}`, {
+                const response = await apiFetch(`${API_URL}/go-heavier/workouts/${set.id}`, {
                     method: "DELETE"
                 })
 
                 if (!response.ok) {
-                    throw new Error("Failed to delete the sets")
+                    throw new ApiError(response.status, "Failed to delete the sets")
                 }
             }
 
@@ -239,18 +248,18 @@ class SessionDetailClass extends React.Component<Props, State> {
         this.setState({ savingEdit: true })
         try {
             for (const set of doomed) {
-                const response = await fetch(`${API_URL}/go-heavier/workouts/${set.id}`, {
+                const response = await apiFetch(`${API_URL}/go-heavier/workouts/${set.id}`, {
                     method: "DELETE"
                 })
 
                 if (!response.ok) {
-                    throw new Error("Failed to delete the set")
+                    throw new ApiError(response.status, "Failed to delete the set")
                 }
             }
 
             for (const set of kept) {
                 const draft = this.state.drafts[set.id]
-                const response = await fetch(`${API_URL}/go-heavier/workouts/${set.id}`, {
+                const response = await apiFetch(`${API_URL}/go-heavier/workouts/${set.id}`, {
                     method: "PUT",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({
@@ -268,7 +277,7 @@ class SessionDetailClass extends React.Component<Props, State> {
                 })
 
                 if (!response.ok) {
-                    throw new Error("Failed to save the changes")
+                    throw new ApiError(response.status, "Failed to save the changes")
                 }
             }
 
@@ -372,13 +381,15 @@ class SessionDetailClass extends React.Component<Props, State> {
                             <div className="detail-section stats-section">
                                 <div className="section-head">
                                     <h3>🏋️ Exercises</h3>
-                                    <button
-                                        type="button"
-                                        className="edit-set-button primary"
-                                        onClick={() => this.setState({ showAddSets: true })}
-                                    >
-                                        ➕ Add sets
-                                    </button>
+                                    {canAccess("POST", "/go-heavier/workouts") && (
+                                        <button
+                                            type="button"
+                                            className="edit-set-button primary"
+                                            onClick={() => this.setState({ showAddSets: true })}
+                                        >
+                                            ➕ Add sets
+                                        </button>
+                                    )}
                                 </div>
 
                                 {this.state.setsLoading && (
@@ -486,24 +497,28 @@ class SessionDetailClass extends React.Component<Props, State> {
                                                 </span>
                                             ) : (
                                                 <span className="session-exercise-edit">
-                                                    <button
-                                                        type="button"
-                                                        className="edit-set-button"
-                                                        onClick={() => this.startEdit(exercise.exercise_id, sets)}
-                                                        disabled={this.state.editingExerciseId !== null}
-                                                        title={`Edit the ${exercise.name} sets`}
-                                                    >
-                                                        ✏️ Edit
-                                                    </button>
-                                                    <button
-                                                        type="button"
-                                                        className="edit-set-button danger"
-                                                        onClick={() => this.askDeleteExercise(exercise.exercise_id, exercise.name, sets)}
-                                                        disabled={this.state.editingExerciseId !== null}
-                                                        title={`Delete every ${exercise.name} set in this session`}
-                                                    >
-                                                        🗑️ Delete all
-                                                    </button>
+                                                    {canAccess("PUT", `/go-heavier/workouts/${exercise.exercise_id}`) && (
+                                                        <button
+                                                            type="button"
+                                                            className="edit-set-button"
+                                                            onClick={() => this.startEdit(exercise.exercise_id, sets)}
+                                                            disabled={this.state.editingExerciseId !== null}
+                                                            title={`Edit the ${exercise.name} sets`}
+                                                        >
+                                                            ✏️ Edit
+                                                        </button>
+                                                    )}
+                                                    {canAccess("DELETE", `/go-heavier/workouts/${exercise.exercise_id}`) && (
+                                                        <button
+                                                            type="button"
+                                                            className="edit-set-button danger"
+                                                            onClick={() => this.askDeleteExercise(exercise.exercise_id, exercise.name, sets)}
+                                                            disabled={this.state.editingExerciseId !== null}
+                                                            title={`Delete every ${exercise.name} set in this session`}
+                                                        >
+                                                            🗑️ Delete all
+                                                        </button>
+                                                    )}
                                                 </span>
                                             )}
                                         </div>

--- a/src/pages/go_heavier/Sessions.tsx
+++ b/src/pages/go_heavier/Sessions.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom"
 
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import SessionForm from "../../components/go_heavier/SessionForm"
+import { canAccess, subscribeAccess, subscribeAccessReady } from "../../roles"
+import { PERMISSION_DENIED_MESSAGE } from "../../configs"
 import {
     formatCount,
     formatDays,
@@ -29,6 +31,7 @@ interface Props {
 
 interface State {
     loaded: boolean | null
+    loadError: string | null
     sessions?: SessionSummary[]
     isRefreshing: boolean
     stats: SessionStats | null
@@ -38,14 +41,23 @@ interface State {
 }
 
 export class Sessions extends React.Component<Props, State> {
+    unsubscribeAccess?: () => void
+    unsubscribeReady?: () => void
+
     constructor(props: Props) {
         super(props)
 
+        // Guards against a cache written before an error response (e.g. a
+        // 403 body) was excluded from what gets cached - an old entry like
+        // that would otherwise be trusted as the session list forever,
+        // since it's truthy and never re-fetched.
         const cachedData = sessionStorage.getItem(SESSIONS_CACHE_KEY)
-        const cachedSessions = cachedData ? JSON.parse(cachedData) : undefined
+        const parsedSessions = cachedData ? JSON.parse(cachedData) : undefined
+        const cachedSessions = Array.isArray(parsedSessions) ? parsedSessions : undefined
 
         this.state = {
             loaded: cachedSessions ? true : null,
+            loadError: null,
             sessions: cachedSessions,
             isRefreshing: false,
             stats: null,
@@ -55,13 +67,47 @@ export class Sessions extends React.Component<Props, State> {
         }
     }
 
-    componentDidMount() {
-        // Cached sessions render straight away; the refresh button is the only
-        // thing that goes back to the API.
-        if (!this.state.sessions) {
-            this.fetchSessions()
+    // Only skip the very first, automatic load - the refresh/retry buttons
+    // call fetchSessions/fetchStats directly and always hit the API, since
+    // clicking one is an explicit request that's worth trying even if we
+    // think it'll fail. Gated independently since they're separate calls
+    // with separate error states.
+    autoFetchSessions = () => {
+        // Checked before the cache: an empty (but validly cached) list looks
+        // exactly like "already loaded, nothing to show" and would otherwise
+        // keep being trusted after a role change revoked access, silently
+        // masking the permission problem behind "No sessions found."
+        if (!canAccess("GET", "/go-heavier/sessions")) {
+            this.setState({ loaded: false, loadError: PERMISSION_DENIED_MESSAGE })
+            return
+        }
+        // Cached sessions render straight away; the refresh button is the
+        // only thing that goes back to the API.
+        if (this.state.sessions) {
+            return
+        }
+        this.fetchSessions()
+    }
+
+    autoFetchStats = () => {
+        if (!canAccess("GET", "/go-heavier/sessions/stats")) {
+            this.setState({ statsLoading: false, statsError: PERMISSION_DENIED_MESSAGE })
+            return
         }
         this.fetchStats()
+    }
+
+    componentDidMount() {
+        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        this.unsubscribeReady = subscribeAccessReady(() => {
+            this.autoFetchSessions()
+            this.autoFetchStats()
+        })
+    }
+
+    componentWillUnmount() {
+        this.unsubscribeAccess?.()
+        this.unsubscribeReady?.()
     }
 
     fetchStats = async () => {
@@ -87,11 +133,11 @@ export class Sessions extends React.Component<Props, State> {
             sessionStorage.setItem(SESSIONS_CACHE_KEY, JSON.stringify(sessions))
 
             await waitOut()
-            this.setState({ sessions, loaded: true, isRefreshing: false })
+            this.setState({ sessions, loaded: true, loadError: null, isRefreshing: false })
         } catch (error) {
             console.error("Error fetching sessions:", error)
             await waitOut()
-            this.setState({ loaded: false, isRefreshing: false })
+            this.setState({ loaded: false, loadError: (error as Error).message, isRefreshing: false })
         }
     }
 
@@ -173,7 +219,9 @@ export class Sessions extends React.Component<Props, State> {
                     {this.state.loaded === false && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Sessions</h2>
-                            <p className="error-message">Unable to fetch sessions from server</p>
+                            <p className="error-message">
+                                {this.state.loadError ?? "Unable to fetch sessions from server"}
+                            </p>
                             <button onClick={this.handleRetry} disabled={this.state.isRefreshing}>
                                 {this.state.isRefreshing ? (
                                     <>
@@ -185,7 +233,7 @@ export class Sessions extends React.Component<Props, State> {
                         </div>
                     )}
 
-                    {this.state.loaded && (
+                    {this.state.loaded && canAccess("POST", "/go-heavier/sessions") && (
                         <button
                             className="add-location-button"
                             onClick={() => this.setState({ showForm: true })}

--- a/src/pages/go_heavier/Stats.tsx
+++ b/src/pages/go_heavier/Stats.tsx
@@ -3,7 +3,9 @@ import { useNavigate } from "react-router-dom"
 
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import BarChart, { BarChartPoint } from "../../components/go_heavier/BarChart"
-import { API_URL } from "../../configs"
+import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../../configs"
+import { canAccess, subscribeAccessReady } from "../../roles"
+import { apiFetch } from "../../auth"
 import {
     MonthlyTotals,
     SessionStats,
@@ -52,10 +54,13 @@ interface State {
     stats: SessionStats | null
     totals: WorkoutTotals | null
     loaded: boolean | null
+    loadError: string | null
     isRefreshing: boolean
 }
 
 export class Stats extends React.Component<Props, State> {
+    unsubscribeReady?: () => void
+
     constructor(props: Props) {
         super(props)
         this.state = {
@@ -63,12 +68,34 @@ export class Stats extends React.Component<Props, State> {
             stats: null,
             totals: null,
             loaded: null,
+            loadError: null,
             isRefreshing: false
         }
     }
 
-    componentDidMount() {
+    // Only skips the very first, automatic load - the refresh/retry buttons
+    // call fetchEverything directly and always hit the API, since clicking
+    // one is an explicit request that's worth trying even if we think it'll
+    // fail. All three underlying requests are needed for this page, so it's
+    // an all-or-nothing check.
+    autoFetch = () => {
+        const canAccessAll =
+            canAccess("GET", "/go-heavier/sessions") &&
+            canAccess("GET", "/go-heavier/sessions/stats") &&
+            canAccess("GET", "/go-heavier/workouts/stats")
+        if (!canAccessAll) {
+            this.setState({ loaded: false, loadError: PERMISSION_DENIED_MESSAGE })
+            return
+        }
         this.fetchEverything()
+    }
+
+    componentDidMount() {
+        this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
+    }
+
+    componentWillUnmount() {
+        this.unsubscribeReady?.()
     }
 
     fetchEverything = async (minDuration: number = 300) => {
@@ -82,20 +109,20 @@ export class Stats extends React.Component<Props, State> {
             const [sessions, stats, totalsRes] = await Promise.all([
                 fetchAllSessions(),
                 fetchSessionStats(),
-                fetch(`${API_URL}/go-heavier/workouts/stats`)
+                apiFetch(`${API_URL}/go-heavier/workouts/stats`)
             ])
 
             if (!totalsRes.ok) {
-                throw new Error("Failed to load totals")
+                throw new ApiError(totalsRes.status, "Failed to load totals")
             }
             const totals = await totalsRes.json()
 
             await waitOut()
-            this.setState({ sessions, stats, totals, loaded: true, isRefreshing: false })
+            this.setState({ sessions, stats, totals, loaded: true, loadError: null, isRefreshing: false })
         } catch (error) {
             console.error("Error fetching stats:", error)
             await waitOut()
-            this.setState({ loaded: false, isRefreshing: false })
+            this.setState({ loaded: false, loadError: (error as Error).message, isRefreshing: false })
         }
     }
 
@@ -173,7 +200,9 @@ export class Stats extends React.Component<Props, State> {
                     {this.state.loaded === false && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Stats</h2>
-                            <p className="error-message">Unable to fetch stats from server</p>
+                            <p className="error-message">
+                                {this.state.loadError ?? "Unable to fetch stats from server"}
+                            </p>
                             <button onClick={this.handleRetry} disabled={this.state.isRefreshing}>
                                 {this.state.isRefreshing ? (
                                     <>

--- a/src/pages/go_heavier/Workouts.tsx
+++ b/src/pages/go_heavier/Workouts.tsx
@@ -2,7 +2,9 @@ import React from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import WorkoutForm from "../../components/go_heavier/WorkoutForm"
-import { API_URL, WORKOUTS_CACHE_KEY, formatNotes } from "../../configs"
+import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE, WORKOUTS_CACHE_KEY, formatNotes } from "../../configs"
+import { apiFetch } from "../../auth"
+import { canAccess, subscribeAccess, subscribeAccessReady } from "../../roles"
 import { SessionSummary, fetchAllSessions, indexSessions } from "../../components/go_heavier/sessions"
 import { formatTableDateTime } from "../../components/go_heavier/format"
 import "../GoHeavier.css"
@@ -43,6 +45,7 @@ const dedupeById = (workouts: WorkoutData[]): WorkoutData[] => mergeById([], wor
 
 interface State {
     configLoaded: boolean | null
+    loadError: string | null
     workouts?: WorkoutData[]
     sessionsById: Record<string, SessionSummary>
     locations?: any[]
@@ -75,12 +78,20 @@ interface WorkoutsProps {
 
 export class Workouts extends React.Component<WorkoutsProps, State> {
     private tableContainerRef: React.RefObject<HTMLDivElement>
+    unsubscribeAccess?: () => void
+    unsubscribeReady?: () => void
 
     constructor(props: WorkoutsProps) {
         super(props)
         
+        // Guards against a cache written before an error response (e.g. a
+        // 403 body) was excluded from what gets cached - an old entry like
+        // that would otherwise be trusted as the workout list forever,
+        // since it's truthy and never re-fetched (and dedupeById would
+        // throw immediately on a non-array).
         const cachedData = localStorage.getItem(WORKOUTS_CACHE_KEY)
-        const cachedWorkouts = cachedData ? dedupeById(JSON.parse(cachedData)) : undefined
+        const parsedWorkouts = cachedData ? JSON.parse(cachedData) : undefined
+        const cachedWorkouts = Array.isArray(parsedWorkouts) ? dedupeById(parsedWorkouts) : undefined
         
         // Read filters from URL
         const startDate = props.searchParams.get('startDate') || ''
@@ -92,6 +103,7 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         
         this.state = {
             configLoaded: cachedWorkouts ? true : null,
+            loadError: null,
             workouts: cachedWorkouts,
             sessionsById: {},
             locations: [],
@@ -126,7 +138,10 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         const all: WorkoutData[] = []
 
         for (let page = 1; page <= MAX_WORKOUT_PAGES; page++) {
-            const response = await fetch(`${API_URL}/go-heavier/workouts?page=${page}`)
+            const response = await apiFetch(`${API_URL}/go-heavier/workouts?page=${page}`)
+            if (!response.ok) {
+                throw new ApiError(response.status, "Failed to load workouts")
+            }
             const pageWorkouts: WorkoutData[] = await response.json()
 
             if (pageWorkouts.length === 0) {
@@ -149,29 +164,37 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
             const [workouts, sessions, locationsRes, exercisesRes] = await Promise.all([
                 this.fetchAllWorkouts(),
                 fetchAllSessions(),
-                fetch(`${API_URL}/go-heavier/locations`),
-                fetch(`${API_URL}/go-heavier/exercises`)
+                apiFetch(`${API_URL}/go-heavier/locations`),
+                apiFetch(`${API_URL}/go-heavier/exercises`)
             ])
-            
+
+            if (!locationsRes.ok) {
+                throw new ApiError(locationsRes.status, "Failed to load locations")
+            }
+            if (!exercisesRes.ok) {
+                throw new ApiError(exercisesRes.status, "Failed to load exercises")
+            }
+
             const locations = await locationsRes.json()
             const exercises = await exercisesRes.json()
-            
+
             localStorage.setItem(WORKOUTS_CACHE_KEY, JSON.stringify(workouts))
-            
+
             await waitOut()
-            this.setState({ 
-                workouts, 
+            this.setState({
+                workouts,
                 sessionsById: indexSessions(sessions),
                 locations,
                 exercises,
-                configLoaded: true, 
+                configLoaded: true,
+                loadError: null,
                 isRefreshing: false,
                 hasFetchedOnce: true
             })
         } catch (error) {
             console.error("Error fetching workouts:", error)
             await waitOut()
-            this.setState({ configLoaded: false, isRefreshing: false })
+            this.setState({ configLoaded: false, loadError: (error as Error).message, isRefreshing: false })
         }
     }
 
@@ -184,7 +207,27 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         this.fetchWorkouts(1000)
     }
 
-    componentDidMount() {
+    // Only skips the very first, automatic load - the refresh/retry buttons
+    // call handleRefresh directly and always hit the API, since clicking one
+    // is an explicit request that's worth trying even if we think it'll
+    // fail. All four underlying requests are needed for this page, so it's
+    // an all-or-nothing check.
+    autoFetch = () => {
+        // Checked before the cache: an empty (but validly cached) list looks
+        // exactly like "already loaded, nothing to show" and would otherwise
+        // keep being trusted after a role change revoked access, silently
+        // masking the permission problem behind "No workouts found."
+        const canAccessAll =
+            canAccess("GET", "/go-heavier/workouts") &&
+            canAccess("GET", "/go-heavier/sessions") &&
+            canAccess("GET", "/go-heavier/locations") &&
+            canAccess("GET", "/go-heavier/exercises")
+
+        if (!canAccessAll) {
+            this.setState({ configLoaded: false, loadError: PERMISSION_DENIED_MESSAGE })
+            return
+        }
+
         if (!this.state.hasFetchedOnce) {
             this.handleRefresh()
         } else {
@@ -194,17 +237,34 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
         }
     }
 
+    componentDidMount() {
+        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
+    }
+
+    componentWillUnmount() {
+        this.unsubscribeAccess?.()
+        this.unsubscribeReady?.()
+    }
+
     fetchSupportingData = async () => {
         try {
             const [sessions, locationsRes, exercisesRes] = await Promise.all([
                 fetchAllSessions(),
-                fetch(`${API_URL}/go-heavier/locations`),
-                fetch(`${API_URL}/go-heavier/exercises`)
+                apiFetch(`${API_URL}/go-heavier/locations`),
+                apiFetch(`${API_URL}/go-heavier/exercises`)
             ])
-            
+
+            if (!locationsRes.ok) {
+                throw new ApiError(locationsRes.status, "Failed to load locations")
+            }
+            if (!exercisesRes.ok) {
+                throw new ApiError(exercisesRes.status, "Failed to load exercises")
+            }
+
             const locations = await locationsRes.json()
             const exercises = await exercisesRes.json()
-            
+
             this.setState({ sessionsById: indexSessions(sessions), locations, exercises })
         } catch (error) {
             console.error("Error fetching sessions/locations/exercises:", error)
@@ -397,7 +457,9 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                     {this.state.configLoaded === false && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Workouts</h2>
-                            <p className="error-message">Unable to fetch workouts from server</p>
+                            <p className="error-message">
+                                {this.state.loadError ?? "Unable to fetch workouts from server"}
+                            </p>
                             <button onClick={this.handleRetry} disabled={this.state.isRefreshing}>
                                 {this.state.isRefreshing ? (
                                     <>
@@ -608,8 +670,8 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                             </table>
                         </div>
                     )}
-                    {this.state.configLoaded && (
-                        <button 
+                    {this.state.configLoaded && canAccess("POST", "/go-heavier/workouts") && (
+                        <button
                             className="add-location-button"
                             onClick={() => {
                                 this.setState({ showForm: true })

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -1,0 +1,200 @@
+// Tracks the signed-in user's role and the API's endpoint -> minimum-role
+// map, so the UI can decide what to render without guessing what the
+// backend will accept. Mirrors the token-outside-React-state pattern in
+// auth.ts: plain functions (canAccess) work in class components, hooks are
+// a thin subscription over the same values for function components.
+import { useEffect, useState } from "react"
+import { API_URL } from "./configs"
+import { apiFetch, getToken, subscribeToken } from "./auth"
+
+export type UserRole = "guest" | "viewer" | "editor" | "admin"
+
+const ROLE_RANK: Record<UserRole, number> = {
+    guest: 0,
+    viewer: 1,
+    editor: 2,
+    admin: 3
+}
+
+// Keyed by path template as FastAPI declares it (e.g.
+// "/go-heavier/exercises/{exercise_id}") then HTTP method. A null role
+// means the endpoint needs no auth at all; a missing method/path means we
+// don't know about it yet (fail closed, see requiredRole below).
+type EndpointRoles = Record<string, Record<string, UserRole | null>>
+
+let role: UserRole | null = null
+let endpointRoles: EndpointRoles | null = null
+const changeListeners = new Set<() => void>()
+
+// Flips true once the first role + endpoint-map fetch (or the decision that
+// there's no token to fetch with) has settled. Callers that want to skip
+// fetching a resource the caller can't access need to wait for this first -
+// otherwise every page load would race the /users and /endpoints requests
+// and wrongly treat a fully-authorized user as having no access yet.
+let accessReady = false
+const readyListeners = new Set<() => void>()
+
+function notify(): void {
+    changeListeners.forEach(listener => listener())
+}
+
+function markAccessReady(): void {
+    if (!accessReady) {
+        accessReady = true
+        readyListeners.forEach(listener => listener())
+    }
+}
+
+function setRole(next: UserRole | null): void {
+    role = next
+    notify()
+}
+
+function setEndpointRoles(next: EndpointRoles | null): void {
+    endpointRoles = next
+    notify()
+}
+
+async function fetchRole(): Promise<void> {
+    try {
+        const response = await apiFetch(`${API_URL}/users`)
+        if (!response.ok) {
+            setRole(null)
+            return
+        }
+        const data = await response.json()
+        setRole(data.role ?? null)
+    } catch (error) {
+        console.error("Failed to fetch user role", error)
+        setRole(null)
+    }
+}
+
+async function fetchEndpointRoles(): Promise<void> {
+    try {
+        const response = await apiFetch(`${API_URL}/endpoints`)
+        if (!response.ok) {
+            return
+        }
+        setEndpointRoles(await response.json())
+    } catch (error) {
+        console.error("Failed to fetch endpoint roles", error)
+    }
+}
+
+// A signed-out visitor has no role and /endpoints requires a valid token
+// (see its API docstring), so both reset together on sign-out.
+subscribeToken(token => {
+    if (token) {
+        Promise.all([fetchRole(), fetchEndpointRoles()]).finally(markAccessReady)
+    } else {
+        setRole(null)
+        setEndpointRoles(null)
+        markAccessReady()
+    }
+})
+
+if (getToken()) {
+    Promise.all([fetchRole(), fetchEndpointRoles()]).finally(markAccessReady)
+} else {
+    markAccessReady()
+}
+
+function pathSegments(path: string): string[] {
+    return path
+        .replace(API_URL, "")
+        .split("?")[0]
+        .split("/")
+        .filter(Boolean)
+}
+
+function matchesTemplate(actual: string[], template: string[]): boolean {
+    return (
+        actual.length === template.length &&
+        template.every((segment, i) => segment.startsWith("{") || segment === actual[i])
+    )
+}
+
+// undefined = endpoint not found in the map (map may still be loading).
+function requiredRole(method: string, path: string): UserRole | null | undefined {
+    if (!endpointRoles) {
+        return undefined
+    }
+    const actual = pathSegments(path)
+    for (const [template, methods] of Object.entries(endpointRoles)) {
+        if (matchesTemplate(actual, template.split("/").filter(Boolean))) {
+            const forMethod = methods[method.toUpperCase()]
+            if (forMethod !== undefined) {
+                return forMethod
+            }
+        }
+    }
+    return undefined
+}
+
+// Whether the signed-in user can call `method path` on the API, per the
+// role the backend itself reports for that endpoint. Fails closed: unknown
+// endpoints and an unloaded /endpoints map both read as "no access" rather
+// than showing an affordance that would 401/403 when used.
+export function canAccess(method: string, path: string): boolean {
+    const min = requiredRole(method, path)
+    if (min === undefined) {
+        return false
+    }
+    if (min === null) {
+        return true
+    }
+    if (!role) {
+        return false
+    }
+    return ROLE_RANK[role] >= ROLE_RANK[min]
+}
+
+export function getUserRole(): UserRole | null {
+    return role
+}
+
+// Whether canAccess has enough information to give a real answer yet. A
+// caller that wants to skip fetching something it might not have access to
+// should wait for this before trusting a `false` from canAccess - before
+// it's ready, `false` just means "still loading", not "denied".
+export function isAccessReady(): boolean {
+    return accessReady
+}
+
+// Fires once, the moment isAccessReady() becomes true (never again after).
+export function subscribeAccessReady(listener: () => void): () => void {
+    if (accessReady) {
+        listener()
+        return () => {}
+    }
+    readyListeners.add(listener)
+    return () => {
+        readyListeners.delete(listener)
+    }
+}
+
+// For class components: re-render whenever role or the endpoint map
+// changes, e.g. `componentDidMount() { this.unsubscribe = subscribeAccess(() => this.forceUpdate()) }`.
+export function subscribeAccess(listener: () => void): () => void {
+    changeListeners.add(listener)
+    return () => {
+        changeListeners.delete(listener)
+    }
+}
+
+export function useCanAccess(method: string, path: string): boolean {
+    const [, forceRender] = useState(0)
+    useEffect(() => subscribeAccess(() => forceRender(n => n + 1)), [])
+    return canAccess(method, path)
+}
+
+export function useUserRole(): UserRole | null {
+    const [current, setCurrent] = useState(role)
+    useEffect(() => subscribeAccess(() => setCurrent(role)), [])
+    return current
+}
+
+export function useIsAdmin(): boolean {
+    return useUserRole() === "admin"
+}


### PR DESCRIPTION
## Summary
- Wires the frontend to the API's new auth/RBAC support: Google Sign-In, a token held outside React state and attached to every API call, and a `canAccess(method, path)` helper (driven by `GET /endpoints`) that gates every add/edit/delete affordance across the go_heavier pages
- Adds a root-level Admin page/tab, visible only to admins
- 403s show a clear "permission denied" message instead of a generic fetch-failure banner, and pages skip fetching a resource entirely when the caller has no access - except via the explicit refresh/retry button, which always tries
- Fixes two latent cache bugs surfaced while building this: an error response body could get cached as if it were real data, and an empty (but validly cached) list was trusted the same as a real load, both of which could mask a permission problem behind a misleading empty state
- Separately, fixes deep-link 404s on GitHub Pages (the standard spa-github-pages 404.html redirect trick), since GitHub Pages only serves static files and has no way to hand a route like `/go-heavier` to React Router on a direct load or refresh

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full test suite passes (81 tests)
- [x] Manually verified dev server compiles and serves all pages
- [x] Verified the 404.html/index.html redirect round-trip (including query params and hash) against a simulated GitHub Pages static server
- [ ] Manual pass in a browser with a guest vs. promoted account, to confirm gating and the permission-denied messaging read correctly end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)