### PR TITLE
Collapse the Go Heavier nav into a hamburger menu on mobile

### DIFF
--- a/src/components/go_heavier/NavBar.css
+++ b/src/components/go_heavier/NavBar.css
@@ -61,24 +61,50 @@
     display: none;
 }
 
+.navbar-menu-toggle {
+    display: none;
+    background: rgba(255, 255, 255, 0.1);
+    border: none;
+    color: white;
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.navbar-menu-toggle:hover {
+    background: rgba(255, 255, 255, 0.25);
+}
+
 /* Responsive design */
 @media (max-width: 640px) {
     .navbar-content {
-        flex-direction: column;
+        position: relative;
         text-align: center;
         gap: 12px;
         padding: 16px;
     }
 
+    .navbar-menu-toggle {
+        display: block;
+    }
+
     .navbar-links {
+        display: none;
         flex-direction: column;
         width: 100%;
         gap: 8px;
     }
 
+    .navbar-links.open {
+        display: flex;
+    }
+
     .navbar-links a {
         width: 100%;
         text-align: center;
+        box-sizing: border-box;
     }
 
     .navbar-brand {

--- a/src/components/go_heavier/NavBar.tsx
+++ b/src/components/go_heavier/NavBar.tsx
@@ -1,50 +1,48 @@
+import { useEffect, useState } from "react"
 import { Link, useLocation } from "react-router-dom"
 import "./NavBar.css"
 
+const LINKS = [
+    { to: "/go-heavier", label: "🏠 Dashboard", exact: true },
+    { to: "/go-heavier/locations", label: "📍 Locations", exact: false },
+    { to: "/go-heavier/exercises", label: "🏋️ Exercises", exact: false },
+    { to: "/go-heavier/sessions", label: "🗓️ Sessions", exact: false },
+    { to: "/go-heavier/stats", label: "📈 Stats", exact: true },
+    { to: "/go-heavier/workouts", label: "📋 Workouts", exact: true }
+]
+
 export default function GoHeavierNavBar() {
     const location = useLocation()
+    const [menuOpen, setMenuOpen] = useState(false)
+
+    // A link tap should close the mobile menu rather than leave it open over
+    // the page it just navigated to.
+    useEffect(() => {
+        setMenuOpen(false)
+    }, [location.pathname])
+
+    const isActive = (to: string, exact: boolean) =>
+        exact ? location.pathname === to : location.pathname === to || location.pathname.startsWith(`${to}/`)
 
     return (
         <div className="go-heavier-navbar">
             <div className="navbar-content">
                 <h1 className="navbar-brand">💪 Go Heavier</h1>
-                <nav className="navbar-links">
-                    <Link 
-                        to="/go-heavier" 
-                        className={location.pathname === "/go-heavier" ? "active" : ""}
-                    >
-                        🏠 Dashboard
-                    </Link>
-                    <Link 
-                        to="/go-heavier/locations" 
-                        className={location.pathname === "/go-heavier/locations" || location.pathname.startsWith("/go-heavier/locations/") ? "active" : ""}
-                    >
-                        📍 Locations
-                    </Link>
-                    <Link 
-                        to="/go-heavier/exercises" 
-                        className={location.pathname === "/go-heavier/exercises" || location.pathname.startsWith("/go-heavier/exercises/") ? "active" : ""}
-                    >
-                        🏋️ Exercises
-                    </Link>
-                    <Link 
-                        to="/go-heavier/sessions" 
-                        className={location.pathname === "/go-heavier/sessions" || location.pathname.startsWith("/go-heavier/sessions/") ? "active" : ""}
-                    >
-                        🗓️ Sessions
-                    </Link>
-                    <Link 
-                        to="/go-heavier/stats" 
-                        className={location.pathname === "/go-heavier/stats" ? "active" : ""}
-                    >
-                        📈 Stats
-                    </Link>
-                    <Link
-                        to="/go-heavier/workouts"
-                        className={location.pathname === "/go-heavier/workouts" ? "active" : ""}
-                    >
-                        📋 Workouts
-                    </Link>
+                <button
+                    type="button"
+                    className="navbar-menu-toggle"
+                    aria-label={menuOpen ? "Close menu" : "Open menu"}
+                    aria-expanded={menuOpen}
+                    onClick={() => setMenuOpen((open) => !open)}
+                >
+                    {menuOpen ? "✕" : "☰"}
+                </button>
+                <nav className={`navbar-links ${menuOpen ? "open" : ""}`}>
+                    {LINKS.map((link) => (
+                        <Link key={link.to} to={link.to} className={isActive(link.to, link.exact) ? "active" : ""}>
+                            {link.label}
+                        </Link>
+                    ))}
                 </nav>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Below 640px, the Go Heavier nav's six links used to stack full-width under the brand, taking up roughly half the viewport before any real content showed.
- They now collapse behind a hamburger toggle, opening as a dropdown panel and auto-closing on navigation. Desktop layout (>640px) is unchanged.

## Test plan
- [x] `tsc --noEmit`
- [x] Full Jest suite (81 tests)
- [x] Verified in the browser: toggle opens/closes, icon flips ☰/✕, menu closes automatically after a link click, desktop layout unaffected