### PR TITLE
Collapse the Admin nav into a hamburger menu on mobile

### DIFF
--- a/src/components/admin/NavBar.css
+++ b/src/components/admin/NavBar.css
@@ -59,23 +59,49 @@
     font-weight: 600;
 }
 
+.admin-navbar-menu-toggle {
+    display: none;
+    background: rgba(255, 255, 255, 0.1);
+    border: none;
+    color: white;
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.admin-navbar-menu-toggle:hover {
+    background: rgba(255, 255, 255, 0.25);
+}
+
 @media (max-width: 640px) {
     .admin-navbar-content {
-        flex-direction: column;
+        position: relative;
         text-align: center;
         gap: 12px;
         padding: 16px;
     }
 
+    .admin-navbar-menu-toggle {
+        display: block;
+    }
+
     .admin-navbar-links {
+        display: none;
         flex-direction: column;
         width: 100%;
         gap: 8px;
     }
 
+    .admin-navbar-links.open {
+        display: flex;
+    }
+
     .admin-navbar-links a {
         width: 100%;
         text-align: center;
+        box-sizing: border-box;
     }
 
     .admin-navbar-brand {

--- a/src/components/admin/NavBar.tsx
+++ b/src/components/admin/NavBar.tsx
@@ -1,24 +1,43 @@
+import { useEffect, useState } from "react"
 import { Link, useLocation } from "react-router-dom"
 import "./NavBar.css"
 
+const LINKS = [
+    { to: "/admin", label: "🏠 Dashboard" },
+    { to: "/admin/provision", label: "➕ Provision" },
+    { to: "/admin/users", label: "👥 Users" }
+]
+
 export default function AdminNavBar() {
     const location = useLocation()
+    const [menuOpen, setMenuOpen] = useState(false)
     const isActive = (to: string) => location.pathname === to
+
+    // A link tap should close the mobile menu rather than leave it open over
+    // the page it just navigated to.
+    useEffect(() => {
+        setMenuOpen(false)
+    }, [location.pathname])
 
     return (
         <div className="admin-navbar">
             <div className="admin-navbar-content">
                 <h1 className="admin-navbar-brand">🔧 Admin</h1>
-                <nav className="admin-navbar-links">
-                    <Link to="/admin" className={isActive("/admin") ? "active" : ""}>
-                        🏠 Dashboard
-                    </Link>
-                    <Link to="/admin/provision" className={isActive("/admin/provision") ? "active" : ""}>
-                        ➕ Provision
-                    </Link>
-                    <Link to="/admin/users" className={isActive("/admin/users") ? "active" : ""}>
-                        👥 Users
-                    </Link>
+                <button
+                    type="button"
+                    className="admin-navbar-menu-toggle"
+                    aria-label={menuOpen ? "Close menu" : "Open menu"}
+                    aria-expanded={menuOpen}
+                    onClick={() => setMenuOpen((open) => !open)}
+                >
+                    {menuOpen ? "✕" : "☰"}
+                </button>
+                <nav className={`admin-navbar-links ${menuOpen ? "open" : ""}`}>
+                    {LINKS.map((link) => (
+                        <Link key={link.to} to={link.to} className={isActive(link.to) ? "active" : ""}>
+                            {link.label}
+                        </Link>
+                    ))}
                 </nav>
             </div>
         </div>


### PR DESCRIPTION
## Summary
Same fix as #25, applied to the Admin sub-nav: below 640px its three links now collapse behind a toggle button instead of stacking full-width.

## Test plan
- [x] `tsc --noEmit`
- [x] Full Jest suite (81 tests)