### PR TITLE
Fix the nav overlapping content, and bound the spinning logo's hit area

### DIFF
--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -20,6 +20,7 @@
     margin: 0 auto;
     padding: 12px 24px;
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
     gap: 16px;
@@ -76,6 +77,23 @@
     font-weight: 600;
 }
 
+.site-navbar-menu-toggle {
+    display: none;
+    background: none;
+    border: 1px solid #e8eaed;
+    color: #5a6c7d;
+    font-size: 1.125rem;
+    line-height: 1;
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.site-navbar-menu-toggle:hover {
+    color: #667eea;
+    background: #f4f5fb;
+}
+
 @media (max-width: 640px) {
     .site-navbar-content {
         padding: 12px 16px;
@@ -86,9 +104,28 @@
         font-size: 1rem;
     }
 
+    .site-navbar-menu-toggle {
+        display: block;
+        order: 1;
+    }
+
+    .site-navbar-links {
+        display: none;
+        order: 3;
+        flex-direction: column;
+        align-items: stretch;
+        width: 100%;
+        gap: 4px;
+    }
+
+    .site-navbar-links.open {
+        display: flex;
+    }
+
     .site-navbar-links a {
-        padding: 8px 12px;
+        padding: 10px 12px;
         font-size: 0.875rem;
+        text-align: center;
     }
 }
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { Link, useLocation } from "react-router-dom"
 
 import { useIsAdmin } from "../roles"
@@ -13,6 +13,13 @@ const LINKS = [
 export default function NavBar() {
     const location = useLocation()
     const isAdmin = useIsAdmin()
+    const [menuOpen, setMenuOpen] = useState(false)
+
+    // A link tap should close the mobile menu rather than leave it open over
+    // the page it just navigated to.
+    useEffect(() => {
+        setMenuOpen(false)
+    }, [location.pathname])
 
     const isActive = (to: string) =>
         location.pathname === to || location.pathname.startsWith(`${to}/`)
@@ -30,7 +37,17 @@ export default function NavBar() {
                     <span className="site-brand-name">TheSammy2010</span>
                 </Link>
 
-                <div className="site-navbar-links">
+                <button
+                    type="button"
+                    className="site-navbar-menu-toggle"
+                    aria-label={menuOpen ? "Close menu" : "Open menu"}
+                    aria-expanded={menuOpen}
+                    onClick={() => setMenuOpen((open) => !open)}
+                >
+                    {menuOpen ? "✕" : "☰"}
+                </button>
+
+                <div className={`site-navbar-links ${menuOpen ? "open" : ""}`}>
                     {links.map(link => (
                         <Link
                             key={link.to}

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -6,8 +6,7 @@
 }
 
 /* Removing the old page heading took the clearance between the nav bar and
-   the logo with it - without this, the logo sits flush against the nav and
-   can overlap its links, blocking clicks on Go Heavier/About/Admin. */
+   the logo with it - without this, the logo sits flush against the nav. */
 #image {
   padding-top: 40px;
 }
@@ -20,6 +19,15 @@
   margin-bottom: auto;
   margin-left: auto;
   margin-right: auto;
+  /* The logo's own box is square-ish but not exactly square, so rotating it
+     sweeps its axis-aligned bounding box - and therefore its clickable area
+     - out past its normal footprint at the 45/135/225/315deg points in the
+     spin, wide enough to reach up into the nav bar above and swallow clicks
+     meant for its links. Clipping to a circle keeps the visible logo (it's
+     a ring, already circular) identical while making the spin's hit area
+     exactly its resting diameter at every angle, so it can never grow into
+     the nav no matter how much padding sits between them.  */
+  clip-path: circle(50%);
   animation: rotate 2s infinite linear;
   animation-delay: calc(var(--delay) * -1s);
   transition: 300ms ease-in-out;


### PR DESCRIPTION
## Summary
Root-caused the recurring "logo/circle is in the way of the nav" reports - it wasn't the Home page's decorative logo, it was the root nav itself. Two real issues found and fixed:

- `.site-navbar-content` had no `flex-wrap`. Once Google Sign-In moved into this bar, the row's content (brand + Go Heavier/About + sign-in name/email) could exceed the viewport width with nothing to fall back on - the sign-in widget just ran off the edge of the screen instead of wrapping, on any window narrower than everything fit on one line (not just genuinely mobile widths - confirmed via screenshot at ~590px). Fixed with `flex-wrap: wrap` as a safety net, plus a hamburger menu for Go Heavier/About matching the pattern already used on the Go Heavier and Admin sub-navs.
- Separately: the Home page's spinning logo rotates inside a box that's square-ish but not exactly square, so the rotation sweeps its axis-aligned bounding box (and therefore its clickable area) out past its resting footprint at the diagonal points in the spin. Verified via bounding-rect measurement. The logo is already a ring visually, so clipping it to a circle (`clip-path: circle(50%)`) removes this without changing anything on screen.

## Test plan
- [x] `tsc --noEmit`
- [x] Full Jest suite (81 tests)
- [x] Reproduced the exact overflow from the reported screenshot at 590px width (both signed-out and One-Tap-suggested states), confirmed it no longer clips off-screen