### PR TITLE
Prompt sign-in instead of showing permission-denied to signed-out visitors

### DIFF
--- a/src/components/SignInPrompt.css
+++ b/src/components/SignInPrompt.css
@@ -1,0 +1,25 @@
+.signin-prompt {
+    text-align: center;
+    padding: 60px 20px;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.signin-prompt h2 {
+    color: #2c3e50;
+    margin-bottom: 12px;
+}
+
+.signin-prompt p {
+    color: #718096;
+    margin-bottom: 24px;
+}
+
+.signin-prompt-action {
+    display: flex;
+    justify-content: center;
+}
+
+.signin-prompt-action .site-signin {
+    color: #2c3e50;
+}

--- a/src/components/SignInPrompt.tsx
+++ b/src/components/SignInPrompt.tsx
@@ -1,0 +1,18 @@
+import SignIn from "./SignIn"
+import "./SignInPrompt.css"
+
+interface Props {
+    message?: string
+}
+
+export default function SignInPrompt({ message }: Props) {
+    return (
+        <div className="signin-prompt">
+            <h2>Sign in to continue</h2>
+            <p>{message ?? "You need to be signed in to view this page."}</p>
+            <div className="signin-prompt-action">
+                <SignIn />
+            </div>
+        </div>
+    )
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,7 +1,8 @@
 import { Link } from "react-router-dom"
 
-import { useCanAccess, useIsAdmin } from "../roles"
+import { isSignedIn, useCanAccess, useIsAdmin } from "../roles"
 import AdminNavBar from "../components/admin/NavBar"
+import SignInPrompt from "../components/SignInPrompt"
 import "./admin/AdminForms.css"
 import "./Admin.css"
 
@@ -45,6 +46,8 @@ export default function Admin() {
                             )}
                         </div>
                     </div>
+                ) : !isSignedIn() ? (
+                    <SignInPrompt message="Sign in to view admin tools." />
                 ) : (
                     <p className="admin-restricted">This page is restricted to admins.</p>
                 )}

--- a/src/pages/GoHeavier.tsx
+++ b/src/pages/GoHeavier.tsx
@@ -3,11 +3,12 @@ import { Link, useNavigate } from "react-router-dom"
 
 import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../configs"
 import { apiFetch } from "../auth"
-import { canAccess, subscribeAccess, subscribeAccessReady } from "../roles"
+import { canAccess, isSignedIn, subscribeAccess, subscribeAccessReady } from "../roles"
 import { fetchAllSessions } from "../components/go_heavier/sessions"
 import { formatCount, formatTonnes } from "../components/go_heavier/format"
 import GoHeavierNavBar from "../components/go_heavier/NavBar"
 import LogWorkoutWizard from "../components/go_heavier/LogWorkoutWizard"
+import SignInPrompt from "../components/SignInPrompt"
 import "./GoHeavier.css"
 
 interface Props {
@@ -148,7 +149,11 @@ export class GoHeavier extends React.Component<Props, State> {
                         </div>
                     )}
 
-                    {this.state.loaded === false && (
+                    {this.state.loaded === false && !isSignedIn() && (
+                        <SignInPrompt message="Sign in to view your Go Heavier dashboard." />
+                    )}
+
+                    {this.state.loaded === false && isSignedIn() && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Dashboard</h2>
                             <p className="error-message">

--- a/src/pages/admin/ProvisionUser.tsx
+++ b/src/pages/admin/ProvisionUser.tsx
@@ -2,9 +2,10 @@ import React, { useState } from "react"
 
 import { API_URL, ApiError } from "../../configs"
 import { apiFetch } from "../../auth"
-import { useCanAccess, useIsAdmin, UserRole } from "../../roles"
+import { isSignedIn, useCanAccess, useIsAdmin, UserRole } from "../../roles"
 import AdminNavBar from "../../components/admin/NavBar"
 import RoleSelect from "../../components/admin/RoleSelect"
+import SignInPrompt from "../../components/SignInPrompt"
 import "./AdminForms.css"
 
 interface UserResult {
@@ -64,7 +65,9 @@ export default function ProvisionUser() {
             <AdminNavBar />
             <div className="page-container">
                 <div className="admin-form-page">
-                    {!isAdmin ? (
+                    {!isSignedIn() ? (
+                        <SignInPrompt message="Sign in to provision a user." />
+                    ) : !isAdmin ? (
                         <p className="admin-restricted">This page is restricted to admins.</p>
                     ) : !canProvision ? null : (
                         <>

--- a/src/pages/admin/Users.tsx
+++ b/src/pages/admin/Users.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useState } from "react"
 
 import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../../configs"
 import { apiFetch } from "../../auth"
-import { useCanAccess, useIsAdmin, useOwnUserId, UserRole } from "../../roles"
+import { isSignedIn, useCanAccess, useIsAdmin, useOwnUserId, UserRole } from "../../roles"
 import AdminNavBar from "../../components/admin/NavBar"
 import RoleSelect from "../../components/admin/RoleSelect"
+import SignInPrompt from "../../components/SignInPrompt"
 import "./AdminForms.css"
 import "./Users.css"
 
@@ -102,7 +103,9 @@ export default function Users() {
             <AdminNavBar />
             <div className="page-container">
                 <div className="admin-form-page admin-users-page">
-                    {!isAdmin ? (
+                    {!isSignedIn() ? (
+                        <SignInPrompt message="Sign in to manage users." />
+                    ) : !isAdmin ? (
                         <p className="admin-restricted">This page is restricted to admins.</p>
                     ) : (
                         <>

--- a/src/pages/go_heavier/Exercises.tsx
+++ b/src/pages/go_heavier/Exercises.tsx
@@ -4,7 +4,8 @@ import Exercise from "../../components/go_heavier/Exercise"
 import ExerciseForm from "../../components/go_heavier/ExerciseForm"
 import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../../configs"
 import { apiFetch } from "../../auth"
-import { canAccess, subscribeAccess, subscribeAccessReady } from "../../roles"
+import { canAccess, isSignedIn, subscribeAccess, subscribeAccessReady } from "../../roles"
+import SignInPrompt from "../../components/SignInPrompt"
 import "../GoHeavier.css"
 import "./Exercises.css"
 
@@ -233,7 +234,10 @@ export default class Exercises extends React.Component<{}, State> {
                             <div className="spinner"></div>
                         </div>
                     )}
-                    {this.state.configLoaded === false && (
+                    {this.state.configLoaded === false && !isSignedIn() && (
+                        <SignInPrompt message="Sign in to view exercises." />
+                    )}
+                    {this.state.configLoaded === false && isSignedIn() && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Exercises</h2>
                             <p className="error-message">

--- a/src/pages/go_heavier/Locations.tsx
+++ b/src/pages/go_heavier/Locations.tsx
@@ -2,10 +2,11 @@ import React from "react"
 
 import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../../configs"
 import { apiFetch } from "../../auth"
-import { canAccess, subscribeAccess, subscribeAccessReady } from "../../roles"
+import { canAccess, isSignedIn, subscribeAccess, subscribeAccessReady } from "../../roles"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import Location from "../../components/go_heavier/Location"
 import LocationForm from "../../components/go_heavier/LocationForm"
+import SignInPrompt from "../../components/SignInPrompt"
 import "../GoHeavier.css"
 import "./Locations.css"
 
@@ -121,7 +122,10 @@ export default class Locations extends React.Component<{}, State> {
                         <div className="spinner"></div>
                     </div>
                 )}
-                {this.state.configLoaded === false && (
+                {this.state.configLoaded === false && !isSignedIn() && (
+                    <SignInPrompt message="Sign in to view locations." />
+                )}
+                {this.state.configLoaded === false && isSignedIn() && (
                     <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                         <h2>Failed to Load Locations</h2>
                         <p className="error-message">

--- a/src/pages/go_heavier/Sessions.tsx
+++ b/src/pages/go_heavier/Sessions.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from "react-router-dom"
 
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import SessionForm from "../../components/go_heavier/SessionForm"
-import { canAccess, subscribeAccess, subscribeAccessReady } from "../../roles"
+import { canAccess, isSignedIn, subscribeAccess, subscribeAccessReady } from "../../roles"
+import SignInPrompt from "../../components/SignInPrompt"
 import { PERMISSION_DENIED_MESSAGE } from "../../configs"
 import {
     formatCount,
@@ -216,7 +217,10 @@ export class Sessions extends React.Component<Props, State> {
                         </div>
                     )}
 
-                    {this.state.loaded === false && (
+                    {this.state.loaded === false && !isSignedIn() && (
+                        <SignInPrompt message="Sign in to view sessions." />
+                    )}
+                    {this.state.loaded === false && isSignedIn() && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Sessions</h2>
                             <p className="error-message">

--- a/src/pages/go_heavier/Stats.tsx
+++ b/src/pages/go_heavier/Stats.tsx
@@ -4,7 +4,8 @@ import { useNavigate } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import BarChart, { BarChartPoint } from "../../components/go_heavier/BarChart"
 import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../../configs"
-import { canAccess, subscribeAccessReady } from "../../roles"
+import { canAccess, isSignedIn, subscribeAccessReady } from "../../roles"
+import SignInPrompt from "../../components/SignInPrompt"
 import { apiFetch } from "../../auth"
 import {
     MonthlyTotals,
@@ -197,7 +198,10 @@ export class Stats extends React.Component<Props, State> {
                         </div>
                     )}
 
-                    {this.state.loaded === false && (
+                    {this.state.loaded === false && !isSignedIn() && (
+                        <SignInPrompt message="Sign in to view stats." />
+                    )}
+                    {this.state.loaded === false && isSignedIn() && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Stats</h2>
                             <p className="error-message">

--- a/src/pages/go_heavier/Workouts.tsx
+++ b/src/pages/go_heavier/Workouts.tsx
@@ -4,7 +4,8 @@ import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import WorkoutForm from "../../components/go_heavier/WorkoutForm"
 import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE, WORKOUTS_CACHE_KEY, formatNotes } from "../../configs"
 import { apiFetch } from "../../auth"
-import { canAccess, subscribeAccess, subscribeAccessReady } from "../../roles"
+import { canAccess, isSignedIn, subscribeAccess, subscribeAccessReady } from "../../roles"
+import SignInPrompt from "../../components/SignInPrompt"
 import { SessionSummary, fetchAllSessions, indexSessions } from "../../components/go_heavier/sessions"
 import { formatTableDateTime } from "../../components/go_heavier/format"
 import "../GoHeavier.css"
@@ -454,7 +455,10 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
                         {this.showLoading()}
                     </div>
 
-                    {this.state.configLoaded === false && (
+                    {this.state.configLoaded === false && !isSignedIn() && (
+                        <SignInPrompt message="Sign in to view workouts." />
+                    )}
+                    {this.state.configLoaded === false && isSignedIn() && (
                         <div className={`error-container ${this.state.isRefreshing ? 'retrying' : ''}`}>
                             <h2>Failed to Load Workouts</h2>
                             <p className="error-message">

--- a/src/roles.ts
+++ b/src/roles.ts
@@ -167,6 +167,14 @@ export function getOwnUserId(): string | null {
     return ownUserId
 }
 
+// Distinguishes "not signed in at all" from "signed in but lacking a role" -
+// a real account always has at least guest, so canAccess() reading false
+// can't tell those apart on its own, and a permission-denied message is the
+// wrong thing to show someone who hasn't signed in yet.
+export function isSignedIn(): boolean {
+    return getToken() !== null
+}
+
 // Whether canAccess has enough information to give a real answer yet. A
 // caller that wants to skip fetching something it might not have access to
 // should wait for this before trusting a `false` from canAccess - before


### PR DESCRIPTION
## Summary
`canAccess()` fails closed for both "not signed in" and "signed in but lacking a role" - correct for gating actions, but a poor error message: a visitor who's never signed in saw "Failed to Load Dashboard / you don't have permission to do this," which reads as a dead end rather than what's actually needed, one click away.

- Adds `isSignedIn()` to `roles.ts` - a real account always has at least `guest`, so it's the only way to tell "no token" apart from "no role."
- Adds a shared `SignInPrompt` component with an embedded sign-in button.
- Applied everywhere the same fail-closed pattern shows a full-page error: the Go Heavier dashboard and its five sub-pages (Locations, Exercises, Sessions, Stats, Workouts), and Admin and its two sub-pages (Provision, Users).

## Test plan
- [x] `tsc --noEmit`
- [x] Full Jest suite (81 tests)
- [x] Verified in the browser, signed out: Go Heavier dashboard, Locations, and Admin all now show "Sign in to continue" with a working sign-in button instead of the permission-denied error