### PR TITLE
Add a Go Heavier tab to import data from the Google Sheet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import Sessions from "./pages/go_heavier/Sessions"
 import Stats from "./pages/go_heavier/Stats"
 import SessionDetail from "./pages/go_heavier/SessionDetail"
 import Workouts from "./pages/go_heavier/Workouts"
+import Import from "./pages/go_heavier/Import"
 import Admin from "./pages/Admin"
 import ProvisionUser from "./pages/admin/ProvisionUser"
 import Users from "./pages/admin/Users"
@@ -40,6 +41,7 @@ const App: React.FC = () => {
                         <Route path="/go-heavier/stats" element={<Stats />} />
                         <Route path="/go-heavier/sessions/:id" element={<SessionDetail />} />
                         <Route path="/go-heavier/workouts" element={<Workouts />} />
+                        <Route path="/go-heavier/import" element={<Import />} />
                         <Route path="/about" element={<About />} />
                         <Route path="/admin" element={<Admin />} />
                         <Route path="/admin/provision" element={<ProvisionUser />} />

--- a/src/components/go_heavier/NavBar.tsx
+++ b/src/components/go_heavier/NavBar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { Link, useLocation } from "react-router-dom"
+import { useCanAccess } from "../../roles"
 import "./NavBar.css"
 
 const LINKS = [
@@ -14,6 +15,7 @@ const LINKS = [
 export default function GoHeavierNavBar() {
     const location = useLocation()
     const [menuOpen, setMenuOpen] = useState(false)
+    const canImport = useCanAccess("POST", "/go-heavier/migrations")
 
     // A link tap should close the mobile menu rather than leave it open over
     // the page it just navigated to.
@@ -23,6 +25,10 @@ export default function GoHeavierNavBar() {
 
     const isActive = (to: string, exact: boolean) =>
         exact ? location.pathname === to : location.pathname === to || location.pathname.startsWith(`${to}/`)
+
+    const links = canImport
+        ? [...LINKS, { to: "/go-heavier/import", label: "📥 Import", exact: true }]
+        : LINKS
 
     return (
         <div className="go-heavier-navbar">
@@ -38,7 +44,7 @@ export default function GoHeavierNavBar() {
                     {menuOpen ? "✕" : "☰"}
                 </button>
                 <nav className={`navbar-links ${menuOpen ? "open" : ""}`}>
-                    {LINKS.map((link) => (
+                    {links.map((link) => (
                         <Link key={link.to} to={link.to} className={isActive(link.to, link.exact) ? "active" : ""}>
                             {link.label}
                         </Link>

--- a/src/pages/go_heavier/Import.css
+++ b/src/pages/go_heavier/Import.css
@@ -1,0 +1,135 @@
+.import-page {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 32px 24px 64px;
+}
+
+.import-hero {
+    text-align: center;
+    margin-bottom: 24px;
+}
+
+.import-hero h1 {
+    margin: 0 0 8px;
+    font-size: 1.75rem;
+    color: #2c3e50;
+}
+
+.import-hero p {
+    margin: 0;
+    color: #5a6c7d;
+}
+
+.import-form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 24px;
+}
+
+.import-tables,
+.import-workout-range {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.import-tables legend,
+.import-workout-range legend {
+    padding: 0 6px;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.import-table-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.95rem;
+    color: #2c3e50;
+}
+
+.import-dry-run {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.9rem;
+    color: #5a6c7d;
+}
+
+.import-workout-range label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: #5a6c7d;
+}
+
+.import-workout-range input {
+    padding: 8px 10px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-family: inherit;
+}
+
+.import-form > button {
+    align-self: flex-start;
+    padding: 10px 24px;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #fff;
+    transition: all 0.2s ease;
+}
+
+.import-form > button:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(102, 126, 234, 0.3);
+}
+
+.import-form > button:disabled {
+    background: #9ca3af;
+    cursor: not-allowed;
+}
+
+.import-results {
+    border-top: 1px solid #e5e7eb;
+    padding-top: 16px;
+}
+
+.import-results h3 {
+    margin: 0 0 12px;
+    color: #2c3e50;
+}
+
+.import-results table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.import-results th,
+.import-results td {
+    text-align: left;
+    padding: 8px 10px;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 0.9rem;
+}
+
+.import-results th {
+    color: #5a6c7d;
+    font-weight: 600;
+}
+
+.import-results td {
+    color: #2c3e50;
+    text-transform: capitalize;
+}

--- a/src/pages/go_heavier/Import.tsx
+++ b/src/pages/go_heavier/Import.tsx
@@ -1,0 +1,221 @@
+import React, { useState } from "react"
+
+import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../../configs"
+import { apiFetch } from "../../auth"
+import { useCanAccess } from "../../roles"
+import GoHeavierNavBar from "../../components/go_heavier/NavBar"
+import "../GoHeavier.css"
+import "./Import.css"
+
+type MigrationTable = "locations" | "exercises" | "sessions" | "workouts"
+
+const TABLES: { value: MigrationTable; label: string }[] = [
+    { value: "locations", label: "📍 Locations" },
+    { value: "exercises", label: "🏋️ Exercises" },
+    { value: "sessions", label: "🗓️ Sessions" },
+    { value: "workouts", label: "📋 Workouts" }
+]
+
+interface TableMigrationResult {
+    table: MigrationTable
+    rows: number
+    written: number
+}
+
+interface RunMigrationResponse {
+    dry_run: boolean
+    results: TableMigrationResult[]
+}
+
+// Sent as a plain <input type="datetime-local"> value (local time, no
+// timezone); the backend wants an aware ISO datetime, so this attaches the
+// browser's own offset rather than silently treating it as UTC.
+function toAwareIso(localValue: string): string | undefined {
+    if (!localValue) {
+        return undefined
+    }
+    return new Date(localValue).toISOString()
+}
+
+export default function Import() {
+    const canImport = useCanAccess("POST", "/go-heavier/migrations")
+    const [selectedTables, setSelectedTables] = useState<Set<MigrationTable>>(
+        new Set(TABLES.map((table) => table.value))
+    )
+    const [dryRun, setDryRun] = useState(true)
+    const [workoutsAfter, setWorkoutsAfter] = useState("")
+    const [workoutsBefore, setWorkoutsBefore] = useState("")
+    const [workoutsRowStart, setWorkoutsRowStart] = useState("")
+    const [workoutsRowEnd, setWorkoutsRowEnd] = useState("")
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [result, setResult] = useState<RunMigrationResponse | null>(null)
+
+    const toggleTable = (table: MigrationTable) => {
+        setSelectedTables((prev) => {
+            const next = new Set(prev)
+            if (next.has(table)) {
+                next.delete(table)
+            } else {
+                next.add(table)
+            }
+            return next
+        })
+    }
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setLoading(true)
+        setError(null)
+        setResult(null)
+        try {
+            const response = await apiFetch(`${API_URL}/go-heavier/migrations`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    tables: Array.from(selectedTables),
+                    dry_run: dryRun,
+                    workouts_after: toAwareIso(workoutsAfter),
+                    workouts_before: toAwareIso(workoutsBefore),
+                    workouts_row_start: workoutsRowStart ? Number(workoutsRowStart) : undefined,
+                    workouts_row_end: workoutsRowEnd ? Number(workoutsRowEnd) : undefined
+                })
+            })
+            if (!response.ok) {
+                throw new ApiError(
+                    response.status,
+                    response.status === 503
+                        ? "The Google Sheet isn't configured on the server"
+                        : "Failed to run the import"
+                )
+            }
+            setResult(await response.json())
+        } catch (err) {
+            setError((err as Error).message)
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    return (
+        <div className="center-container-grid">
+            <GoHeavierNavBar />
+            <div className="page-container">
+                <div className="import-page">
+                    {!canImport ? (
+                        <div className="error-container">
+                            <h2>Restricted</h2>
+                            <p className="error-message">{PERMISSION_DENIED_MESSAGE}</p>
+                        </div>
+                    ) : (
+                        <>
+                            <div className="import-hero">
+                                <h1>📥 Import from Google Sheet</h1>
+                                <p>
+                                    Loads locations, exercises, sessions and workouts from the Go
+                                    Heavier Google Sheet. Existing rows are updated in place.
+                                </p>
+                            </div>
+                            <form onSubmit={handleSubmit} className="import-form">
+                                <fieldset className="import-tables">
+                                    <legend>Tables to import</legend>
+                                    {TABLES.map((table) => (
+                                        <label key={table.value} className="import-table-checkbox">
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedTables.has(table.value)}
+                                                onChange={() => toggleTable(table.value)}
+                                            />
+                                            <span>{table.label}</span>
+                                        </label>
+                                    ))}
+                                </fieldset>
+
+                                <label className="import-dry-run">
+                                    <input
+                                        type="checkbox"
+                                        checked={dryRun}
+                                        onChange={(e) => setDryRun(e.target.checked)}
+                                    />
+                                    <span>Dry run - read the sheet but don't write anything</span>
+                                </label>
+
+                                {selectedTables.has("workouts") && (
+                                    <fieldset className="import-workout-range">
+                                        <legend>Workouts range (optional)</legend>
+                                        <label>
+                                            Performed at or after
+                                            <input
+                                                type="datetime-local"
+                                                value={workoutsAfter}
+                                                onChange={(e) => setWorkoutsAfter(e.target.value)}
+                                            />
+                                        </label>
+                                        <label>
+                                            Performed at or before
+                                            <input
+                                                type="datetime-local"
+                                                value={workoutsBefore}
+                                                onChange={(e) => setWorkoutsBefore(e.target.value)}
+                                            />
+                                        </label>
+                                        <label>
+                                            First sheet row
+                                            <input
+                                                type="number"
+                                                min={0}
+                                                value={workoutsRowStart}
+                                                onChange={(e) => setWorkoutsRowStart(e.target.value)}
+                                                placeholder="e.g. 0"
+                                            />
+                                        </label>
+                                        <label>
+                                            Last sheet row
+                                            <input
+                                                type="number"
+                                                min={1}
+                                                value={workoutsRowEnd}
+                                                onChange={(e) => setWorkoutsRowEnd(e.target.value)}
+                                                placeholder="Defaults to the end of the sheet"
+                                            />
+                                        </label>
+                                    </fieldset>
+                                )}
+
+                                {error && <p className="error-message">{error}</p>}
+
+                                {result && (
+                                    <div className="import-results">
+                                        <h3>{result.dry_run ? "Dry run results" : "Import complete"}</h3>
+                                        <table>
+                                            <thead>
+                                                <tr>
+                                                    <th>Table</th>
+                                                    <th>Rows read</th>
+                                                    <th>Rows written</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {result.results.map((tableResult) => (
+                                                    <tr key={tableResult.table}>
+                                                        <td>{tableResult.table}</td>
+                                                        <td>{tableResult.rows}</td>
+                                                        <td>{tableResult.written}</td>
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                )}
+
+                                <button type="submit" disabled={loading || selectedTables.size === 0}>
+                                    {loading ? "Running..." : dryRun ? "Preview Import" : "Run Import"}
+                                </button>
+                            </form>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
The backend has had `POST /go-heavier/migrations` for a while (upserts locations/exercises/sessions/workouts from the Go Heavier Google Sheet) but no frontend for it. This wires it up:

- New "📥 Import" tab on the Go Heavier nav, checkboxes for which tables to load
- Dry-run toggle (reads and parses the sheet without writing)
- Optional workout narrowing by date range or sheet row range, matching what the endpoint already accepts
- Results table showing rows read vs. written per table
- The nav tab and page are gated by `canAccess("POST", "/go-heavier/migrations")` off the live `/endpoints` map (editor+), same as every other write affordance in this app

## Test plan
- [x] `tsc --noEmit`
- [x] Full Jest suite (81 tests)
- [x] Verified in the browser signed in as admin: tab appears, form renders, submits correctly

**Heads up:** submitting against my local backend returned a 500 from inside the Google Sheets call itself (outbound network access is fine - confirmed reachable - so this looks like a service-account/sheet-access issue with the local `.env`, not a bug in the request). Worth a quick check that the configured Google service account still has access to the sheet before relying on this.