### PR TITLE
Fix nav-bar overlap bugs, and simplify One Tap back to Google's default position

### DIFF
--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -9,8 +9,10 @@
 
 /* One Tap renders itself into this element (see prompt_parent_id in
    SignIn.tsx) instead of Google's default fixed top-right overlay, which
-   floated on top of these nav links. position: relative makes it the
-   containing block so the prompt anchors just under the bar. */
+   floated on top of these nav links. Wrapping SignIn itself, rather than a
+   separate full-width sibling, keeps the prompt anchored where the sign-in
+   control actually is instead of left-aligning under the brand logo -
+   position: relative makes it the containing block for Google's popup. */
 .one-tap-anchor {
     position: relative;
 }

--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -7,16 +7,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
-/* One Tap renders itself into this element (see prompt_parent_id in
-   SignIn.tsx) instead of Google's default fixed top-right overlay, which
-   floated on top of these nav links. Wrapping SignIn itself, rather than a
-   separate full-width sibling, keeps the prompt anchored where the sign-in
-   control actually is instead of left-aligning under the brand logo -
-   position: relative makes it the containing block for Google's popup. */
-.one-tap-anchor {
-    position: relative;
-}
-
 .site-navbar-content {
     max-width: 1400px;
     margin: 0 auto;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -59,9 +59,10 @@ export default function NavBar() {
                     ))}
                 </div>
 
-                <SignIn />
+                <div id={ONE_TAP_ANCHOR_ID} className="one-tap-anchor">
+                    <SignIn />
+                </div>
             </div>
-            <div id={ONE_TAP_ANCHOR_ID} className="one-tap-anchor" />
         </nav>
     )
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react"
 import { Link, useLocation } from "react-router-dom"
 
 import { useIsAdmin } from "../roles"
-import SignIn, { ONE_TAP_ANCHOR_ID } from "./SignIn"
+import SignIn from "./SignIn"
 import "./NavBar.css"
 
 const LINKS = [
@@ -59,9 +59,7 @@ export default function NavBar() {
                     ))}
                 </div>
 
-                <div id={ONE_TAP_ANCHOR_ID} className="one-tap-anchor">
-                    <SignIn />
-                </div>
+                <SignIn />
             </div>
         </nav>
     )

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -5,10 +5,6 @@ import { API_URL } from "../configs"
 import { apiFetch, decodeProfile, GoogleProfile, setToken, signOut, useAuthToken } from "../auth"
 import "./SignIn.css"
 
-// Anchors the One Tap prompt here instead of Google's default fixed
-// top-right overlay, which floated on top of the nav bar's own links.
-export const ONE_TAP_ANCHOR_ID = "google-one-tap-anchor"
-
 // A signed-in caller defaults to the "guest" role in the API until an admin
 // promotes them, so a fresh sign-in can still see 401/403s from protected
 // routes - that's expected, not a bug in this component.
@@ -29,11 +25,11 @@ export default function SignIn() {
     useEffect(() => {
         setProfile(token ? decodeProfile(token) : null)
 
-        // Google injects the One Tap picker directly into the DOM outside
-        // React's control (see prompt_parent_id), so unmounting <GoogleLogin>
-        // here doesn't remove it - a prompt that was already showing before
-        // sign-in completed (e.g. a silent re-auth in another tab) would
-        // otherwise linger on screen indefinitely.
+        // Google injects the One Tap picker directly into the page outside
+        // React's control, so unmounting <GoogleLogin> here doesn't remove
+        // it - a prompt that was already showing before sign-in completed
+        // (e.g. a silent re-auth in another tab) would otherwise linger on
+        // screen indefinitely.
         if (token) {
             (window as any).google?.accounts?.id?.cancel?.()
         }
@@ -95,7 +91,6 @@ export default function SignIn() {
                 }}
                 onError={() => console.error("Google sign-in failed")}
                 useOneTap
-                prompt_parent_id={ONE_TAP_ANCHOR_ID}
             />
         </div>
     )

--- a/src/components/SignIn.tsx
+++ b/src/components/SignIn.tsx
@@ -28,6 +28,15 @@ export default function SignIn() {
 
     useEffect(() => {
         setProfile(token ? decodeProfile(token) : null)
+
+        // Google injects the One Tap picker directly into the DOM outside
+        // React's control (see prompt_parent_id), so unmounting <GoogleLogin>
+        // here doesn't remove it - a prompt that was already showing before
+        // sign-in completed (e.g. a silent re-auth in another tab) would
+        // otherwise linger on screen indefinitely.
+        if (token) {
+            (window as any).google?.accounts?.id?.cancel?.()
+        }
     }, [token])
 
     const handleDeleteAccount = async () => {

--- a/src/pages/go_heavier/Exercises.css
+++ b/src/pages/go_heavier/Exercises.css
@@ -1,5 +1,11 @@
 /* Page fade-in animation */
+/* position: relative so .refresh-arrow-button (position: absolute)
+   anchors to where content actually starts, below the sticky nav
+   bars, instead of a fixed viewport offset that assumes a specific
+   combined bar height and ends up overlapping the bars' own
+   contents (brand text, hamburger toggle) when that height varies. */
 .page-container {
+    position: relative;
     animation: pageTransition 0.25s ease-out;
 }
 

--- a/src/pages/go_heavier/LocationDetail.css
+++ b/src/pages/go_heavier/LocationDetail.css
@@ -1,5 +1,11 @@
 /* Page fade-in animation */
+/* position: relative so .refresh-arrow-button (position: absolute)
+   anchors to where content actually starts, below the sticky nav
+   bars, instead of a fixed viewport offset that assumes a specific
+   combined bar height and ends up overlapping the bars' own
+   contents (brand text, hamburger toggle) when that height varies. */
 .page-container {
+    position: relative;
     animation: pageTransition 0.25s ease-out;
 }
 
@@ -363,10 +369,14 @@
 }
 
 /* Refresh arrow button */
+/* Absolute within .page-container (position: relative), not fixed to the
+   viewport - a fixed top offset assumed a specific combined height for the
+   sticky nav bars above, and ended up overlapping their own contents
+   (brand text, hamburger toggle) whenever that height actually varied. */
 .refresh-arrow-button {
-    position: fixed;
-    top: 90px;
-    right: 24px;
+    position: absolute;
+    top: 16px;
+    right: 16px;
     background: #4a90e2;
     color: white;
     border: none;

--- a/src/pages/go_heavier/Locations.css
+++ b/src/pages/go_heavier/Locations.css
@@ -23,7 +23,13 @@
 }
 
 /* Page fade-in animation */
+/* position: relative so .refresh-arrow-button (position: absolute)
+   anchors to where content actually starts, below the sticky nav
+   bars, instead of a fixed viewport offset that assumes a specific
+   combined bar height and ends up overlapping the bars' own
+   contents (brand text, hamburger toggle) when that height varies. */
 .page-container {
+    position: relative;
     animation: pageTransition 0.25s ease-out;
 }
 
@@ -80,11 +86,14 @@
     }
 }
 
-/* Refresh arrow button in top right */
+/* Absolute within .page-container (position: relative), not fixed to the
+   viewport - a fixed top offset assumed a specific combined height for the
+   sticky nav bars above, and ended up overlapping their own contents
+   (brand text, hamburger toggle) whenever that height actually varied. */
 .refresh-arrow-button {
-    position: fixed;
-    top: 90px;
-    right: 24px;
+    position: absolute;
+    top: 16px;
+    right: 16px;
     background: #4a90e2;
     color: white;
     border: none;

--- a/src/pages/go_heavier/Workouts.css
+++ b/src/pages/go_heavier/Workouts.css
@@ -1,5 +1,11 @@
 /* Page fade-in animation */
+/* position: relative so .refresh-arrow-button (position: absolute)
+   anchors to where content actually starts, below the sticky nav
+   bars, instead of a fixed viewport offset that assumes a specific
+   combined bar height and ends up overlapping the bars' own
+   contents (brand text, hamburger toggle) when that height varies. */
 .page-container {
+    position: relative;
     animation: pageTransition 0.25s ease-out;
 }
 


### PR DESCRIPTION
## Summary
From the reported screenshots: the One Tap account picker was floating at the far left of the nav under the brand logo (unrelated to the sign-in control it was offering to fill in for), and separately, the refresh button on Go Heavier/Locations pages was landing on top of the purple bar's brand text or hamburger toggle.

**One Tap**: originally custom-anchored via `prompt_parent_id` to fix what turned out to be a *different* bug entirely (the root nav's missing `flex-wrap`, fixed separately in #27). By the time that was found, the custom anchor was solving a problem that no longer existed while introducing its own (Google left-aligns within whatever box it's given, so the anchor's position mattered and was easy to get wrong). Every other site using One Tap - Medium included, see the comparison screenshot - just lets Google render its own default fixed top-right prompt. Reverted to that default rather than continuing to fight Google's own UI conventions. Kept the `google.accounts.id.cancel()` call on sign-in, since a prompt left open from before sign-in completed not being dismissed is an independent bug from where it renders.

**Refresh button**: `.refresh-arrow-button` was `position: fixed` at a hardcoded `top: 90px`, assuming a specific combined height for the nav bars above it. That assumption broke on mobile - confirmed via screenshot, the button floated on top of the purple bar's own contents. Anchored it to `.page-container` instead (now `position: relative`), so it starts wherever content actually begins regardless of nav height.

## Test plan
- [x] `tsc --noEmit`
- [x] Full Jest suite (93 tests)
- [x] Verified in the browser: refresh button no longer overlaps either nav bar's contents on Go Heavier dashboard or Locations; One Tap no longer has custom positioning code to get wrong