### PR TITLE
Retry the data load when someone signs in without leaving the page

### DIFF
--- a/src/pages/GoHeavier.tsx
+++ b/src/pages/GoHeavier.tsx
@@ -110,7 +110,17 @@ export class GoHeavier extends React.Component<Props, State> {
     }
 
     componentDidMount() {
-        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        // Not just a re-render: signing in (or an admin changing your role)
+        // fires this too, and without retrying autoFetch here, someone who
+        // signs in from the "sign in to continue" prompt on this exact page
+        // would see nothing happen - the one-time subscribeAccessReady
+        // callback already fired, showing that prompt, before they signed in.
+        this.unsubscribeAccess = subscribeAccess(() => {
+            this.forceUpdate()
+            if (!this.state.loaded) {
+                this.autoFetch()
+            }
+        })
         this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
     }
 

--- a/src/pages/go_heavier/Exercises.tsx
+++ b/src/pages/go_heavier/Exercises.tsx
@@ -114,7 +114,17 @@ export default class Exercises extends React.Component<{}, State> {
     }
 
     componentDidMount() {
-        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        // Not just a re-render: signing in (or an admin changing your role)
+        // fires this too, and without retrying autoFetch here, someone who
+        // signs in from the "sign in to continue" prompt on this exact page
+        // would see nothing happen - the one-time subscribeAccessReady
+        // callback already fired, showing that prompt, before they signed in.
+        // autoFetch's own hasFetchedOnce guard keeps this from refetching
+        // once already loaded.
+        this.unsubscribeAccess = subscribeAccess(() => {
+            this.forceUpdate()
+            this.autoFetch()
+        })
         this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
     }
 

--- a/src/pages/go_heavier/Locations.tsx
+++ b/src/pages/go_heavier/Locations.tsx
@@ -92,7 +92,17 @@ export default class Locations extends React.Component<{}, State> {
     }
 
     componentDidMount() {
-        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        // Not just a re-render: signing in (or an admin changing your role)
+        // fires this too, and without retrying autoFetch here, someone who
+        // signs in from the "sign in to continue" prompt on this exact page
+        // would see nothing happen - the one-time subscribeAccessReady
+        // callback already fired, showing that prompt, before they signed in.
+        // autoFetch's own hasFetchedOnce guard keeps this from refetching
+        // once already loaded.
+        this.unsubscribeAccess = subscribeAccess(() => {
+            this.forceUpdate()
+            this.autoFetch()
+        })
         this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
     }
 

--- a/src/pages/go_heavier/Sessions.tsx
+++ b/src/pages/go_heavier/Sessions.tsx
@@ -99,7 +99,20 @@ export class Sessions extends React.Component<Props, State> {
     }
 
     componentDidMount() {
-        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        // Not just a re-render: signing in (or an admin changing your role)
+        // fires this too, and without retrying here, someone who signs in
+        // from the "sign in to continue" prompt on this exact page would see
+        // nothing happen - the one-time subscribeAccessReady callback
+        // already fired, showing that prompt, before they signed in.
+        // autoFetchSessions guards itself against refetching once loaded;
+        // autoFetchStats doesn't, so that one's guarded here instead.
+        this.unsubscribeAccess = subscribeAccess(() => {
+            this.forceUpdate()
+            this.autoFetchSessions()
+            if (!this.state.stats) {
+                this.autoFetchStats()
+            }
+        })
         this.unsubscribeReady = subscribeAccessReady(() => {
             this.autoFetchSessions()
             this.autoFetchStats()

--- a/src/pages/go_heavier/Stats.tsx
+++ b/src/pages/go_heavier/Stats.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom"
 import GoHeavierNavBar from "../../components/go_heavier/NavBar"
 import BarChart, { BarChartPoint } from "../../components/go_heavier/BarChart"
 import { API_URL, ApiError, PERMISSION_DENIED_MESSAGE } from "../../configs"
-import { canAccess, isSignedIn, subscribeAccessReady } from "../../roles"
+import { canAccess, isSignedIn, subscribeAccess, subscribeAccessReady } from "../../roles"
 import SignInPrompt from "../../components/SignInPrompt"
 import { apiFetch } from "../../auth"
 import {
@@ -60,6 +60,7 @@ interface State {
 }
 
 export class Stats extends React.Component<Props, State> {
+    unsubscribeAccess?: () => void
     unsubscribeReady?: () => void
 
     constructor(props: Props) {
@@ -92,10 +93,22 @@ export class Stats extends React.Component<Props, State> {
     }
 
     componentDidMount() {
+        // Not just a re-render: signing in (or an admin changing your role)
+        // fires this too, and without retrying autoFetch here, someone who
+        // signs in from the "sign in to continue" prompt on this exact page
+        // would see nothing happen - the one-time subscribeAccessReady
+        // callback already fired, showing that prompt, before they signed in.
+        this.unsubscribeAccess = subscribeAccess(() => {
+            this.forceUpdate()
+            if (!this.state.loaded) {
+                this.autoFetch()
+            }
+        })
         this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
     }
 
     componentWillUnmount() {
+        this.unsubscribeAccess?.()
         this.unsubscribeReady?.()
     }
 

--- a/src/pages/go_heavier/Workouts.tsx
+++ b/src/pages/go_heavier/Workouts.tsx
@@ -239,7 +239,17 @@ export class Workouts extends React.Component<WorkoutsProps, State> {
     }
 
     componentDidMount() {
-        this.unsubscribeAccess = subscribeAccess(() => this.forceUpdate())
+        // Not just a re-render: signing in (or an admin changing your role)
+        // fires this too, and without retrying autoFetch here, someone who
+        // signs in from the "sign in to continue" prompt on this exact page
+        // would see nothing happen - the one-time subscribeAccessReady
+        // callback already fired, showing that prompt, before they signed in.
+        // autoFetch's own hasFetchedOnce guard keeps this from refetching
+        // once already loaded.
+        this.unsubscribeAccess = subscribeAccess(() => {
+            this.forceUpdate()
+            this.autoFetch()
+        })
         this.unsubscribeReady = subscribeAccessReady(this.autoFetch)
     }
 


### PR DESCRIPTION
## Summary
`subscribeAccessReady` fires exactly once - the moment access first settles, whether that's "signed out" or "signed in with a role." Every Go Heavier page's `autoFetch` was wired only to that one-time callback, so anyone shown the "sign in to continue" prompt (from #28) who then signed in right there, without navigating away or reloading, saw nothing happen - the callback had already fired and nothing else was listening for the role finishing its load.

`subscribeAccess`, by contrast, fires on every access-state change - so `autoFetch` (or the equivalent per-page methods) now also runs from that listener on all six pages (GoHeavier dashboard, Locations, Exercises, Sessions, Stats, Workouts). Most of these already guard themselves against refetching once loaded (`hasFetchedOnce`, or a truthy state field), so calling them again on every access change is a no-op once settled; the two that didn't (GoHeavier's and Stats' `autoFetch`) are guarded at the call site instead. Stats.tsx was also missing the `subscribeAccess` listener entirely, so it wasn't even re-rendering its restricted/sign-in message on a role change.

## Test plan
- [x] `tsc --noEmit`
- [x] Full Jest suite (93 tests)
- [ ] Could not verify live end-to-end: Google's One Tap resists automated clicks in this environment, so I couldn't complete a real sign-in via browser automation to watch the data load fire. The fix follows directly from the code (subscribeAccessReady's documented fire-once behavior), but hasn't been eyeballed in a real browser - worth a quick manual check signing in from a "sign in to continue" page before merging.

## Separately raised, not addressed here
The same report mentioned the Admin nav tile not appearing automatically after signing in. I couldn't reproduce this - `useIsAdmin()` subscribes to every access change, not just the first, so it should update correctly - and my best guess is it's Google's own sign-in confirmation taking a couple of seconds, not a real bug. Flagging in case it turns out to be more than that.